### PR TITLE
Trino Scale-out 기능 추가

### DIFF
--- a/client/app/components/ApplicationArea/ApplicationLayout/DesktopNavbar.jsx
+++ b/client/app/components/ApplicationArea/ApplicationLayout/DesktopNavbar.jsx
@@ -5,6 +5,7 @@ import Link from "@/components/Link";
 import PlainButton from "@/components/PlainButton";
 import HelpTrigger from "@/components/HelpTrigger";
 import CreateDashboardDialog from "@/components/dashboards/CreateDashboardDialog";
+import TrinoScaleoutDialog from "@/components/trino/TrinoScaleoutDialog";
 import { useCurrentRoute } from "@/components/ApplicationArea/Router";
 import { Auth, currentUser } from "@/services/auth";
 import settingsMenu from "@/services/settingsMenu";
@@ -16,6 +17,7 @@ import AlertOutlinedIcon from "@ant-design/icons/AlertOutlined";
 import PlusOutlinedIcon from "@ant-design/icons/PlusOutlined";
 import QuestionCircleOutlinedIcon from "@ant-design/icons/QuestionCircleOutlined";
 import SettingOutlinedIcon from "@ant-design/icons/SettingOutlined";
+import DatabaseOutlinedIcon from "@ant-design/icons/DatabaseOutlined";
 import VersionInfo from "./VersionInfo";
 
 import "./DesktopNavbar.less";
@@ -106,6 +108,12 @@ export default function DesktopNavbar() {
             </Link>
           </Menu.Item>
         )}
+        <Menu.Item key="trino">
+          <PlainButton onClick={() => TrinoScaleoutDialog.showModal()} data-test="TrinoScaleoutMenuItem">
+            <DatabaseOutlinedIcon aria-label="Trino scale-out button" />
+            <span className="desktop-navbar-label">Trino</span>
+          </PlainButton>
+        </Menu.Item>
       </NavbarSection>
 
       <NavbarSection className="desktop-navbar-spacer">

--- a/client/app/components/trino/TrinoScaleoutDialog.jsx
+++ b/client/app/components/trino/TrinoScaleoutDialog.jsx
@@ -1,0 +1,94 @@
+import React, { useState } from "react";
+import Modal from "antd/lib/modal";
+import Button from "antd/lib/button";
+import message from "antd/lib/message";
+import Spin from "antd/lib/spin";
+import Card from "antd/lib/card";
+import Typography from "antd/lib/typography";
+import Space from "antd/lib/space";
+import { wrap as wrapDialog, DialogPropType } from "@/components/DialogWrapper";
+import axios from "@/services/axios";
+
+const { Title, Text } = Typography;
+
+function TrinoScaleoutDialog({ dialog }) {
+  const [scaleoutInProgress, setScaleoutInProgress] = useState(false);
+
+  function handleScaleout() {
+    setScaleoutInProgress(true);
+    
+    // Redis CLI를 통해 Trino Scale-out 요청 보내기
+    axios
+      .post("/api/trino/scaleout")
+      .then(() => {
+        message.success("Trino Scale-out 요청이 성공적으로 전송되었습니다.");
+        dialog.close();
+      })
+      .catch((error) => {
+        message.error("Trino Scale-out 요청 중 오류가 발생했습니다: " + (error?.response?.data?.message || error.message));
+      })
+      .finally(() => {
+        setScaleoutInProgress(false);
+      });
+  }
+
+  return (
+    <Modal
+      {...dialog.props}
+      title={
+        <Space>
+          <img 
+            src="/static/images/db-logos/trino.png" 
+            alt="Trino" 
+            style={{ width: 24, height: 24 }}
+          />
+          Trino Scale-out
+        </Space>
+      }
+      okText="Scale-out 실행"
+      cancelText="취소"
+      okButtonProps={{
+        disabled: scaleoutInProgress,
+        loading: scaleoutInProgress,
+        type: "primary",
+        "data-test": "TrinoScaleoutButton",
+      }}
+      cancelButtonProps={{
+        disabled: scaleoutInProgress,
+      }}
+      onOk={handleScaleout}
+      closable={!scaleoutInProgress}
+      maskClosable={!scaleoutInProgress}
+      wrapProps={{
+        "data-test": "TrinoScaleoutDialog",
+      }}
+      width={480}
+    >
+      <Card>
+        <Space direction="vertical" style={{ width: '100%' }}>
+          <Title level={4}>Trino 클러스터 확장</Title>
+          <Text>
+            대용량 쿼리 실행을 위해 Trino 클러스터를 Scale-out 하시겠습니까?
+          </Text>
+          <Text type="secondary">
+            이 작업은 Redis를 통해 Trino 클러스터에 확장 명령을 전송합니다.
+          </Text>
+          {scaleoutInProgress && (
+            <div style={{ textAlign: 'center', padding: '20px 0' }}>
+              <Spin size="large" />
+              <div style={{ marginTop: 16 }}>
+                <Text>Scale-out 요청을 처리 중입니다...</Text>
+              </div>
+            </div>
+          )}
+        </Space>
+      </Card>
+    </Modal>
+  );
+}
+
+TrinoScaleoutDialog.propTypes = {
+  dialog: DialogPropType.isRequired,
+};
+
+export default wrapDialog(TrinoScaleoutDialog);

--- a/redash/handlers/api.py
+++ b/redash/handlers/api.py
@@ -80,6 +80,7 @@ from redash.handlers.query_snippets import (
     QuerySnippetListResource,
     QuerySnippetResource,
 )
+from redash.handlers.trino import TrinoScaleoutResource
 from redash.handlers.settings import OrganizationSettings
 from redash.handlers.users import (
     UserDisableResource,
@@ -283,5 +284,7 @@ api.add_org_resource(DestinationListResource, "/api/destinations", endpoint="des
 
 api.add_org_resource(QuerySnippetResource, "/api/query_snippets/<snippet_id>", endpoint="query_snippet")
 api.add_org_resource(QuerySnippetListResource, "/api/query_snippets", endpoint="query_snippets")
+
+api.add_org_resource(TrinoScaleoutResource, "/api/trino/scaleout", endpoint="trino_scaleout")
 
 api.add_org_resource(OrganizationSettings, "/api/settings/organization", endpoint="organization_settings")

--- a/redash/handlers/trino.py
+++ b/redash/handlers/trino.py
@@ -1,0 +1,73 @@
+import subprocess
+import logging
+
+from flask import request
+from flask_restful import Resource
+
+from redash.handlers.base import BaseResource, require_fields
+from redash.permissions import require_permission
+
+logger = logging.getLogger(__name__)
+
+
+class TrinoScaleoutResource(BaseResource):
+    @require_permission("admin")
+    def post(self):
+        """
+        Trino 클러스터 Scale-out 요청을 Redis CLI를 통해 전송합니다.
+        """
+        try:
+            # Redis CLI를 통해 Trino Scale-out 명령 전송
+            # 실제 환경에 맞게 Redis 호스트, 포트, 명령어를 수정해야 합니다
+            redis_command = [
+                "redis-cli", 
+                "-h", "localhost",  # Redis 호스트 (환경에 맞게 수정)
+                "-p", "6379",       # Redis 포트 (환경에 맞게 수정)
+                "publish", 
+                "trino-scaleout",   # Redis 채널명 (환경에 맞게 수정)
+                "scale-out-request" # 메시지 (환경에 맞게 수정)
+            ]
+            
+            # Redis CLI 명령 실행
+            result = subprocess.run(
+                redis_command,
+                capture_output=True,
+                text=True,
+                timeout=30  # 30초 타임아웃
+            )
+            
+            if result.returncode == 0:
+                logger.info(f"Trino scale-out request sent successfully. Output: {result.stdout}")
+                return {
+                    "success": True,
+                    "message": "Trino Scale-out 요청이 성공적으로 전송되었습니다.",
+                    "redis_response": result.stdout.strip()
+                }
+            else:
+                logger.error(f"Redis CLI command failed. Error: {result.stderr}")
+                return {
+                    "success": False,
+                    "message": f"Redis CLI 명령 실행 실패: {result.stderr}",
+                    "error_code": result.returncode
+                }, 500
+                
+        except subprocess.TimeoutExpired:
+            logger.error("Redis CLI command timed out")
+            return {
+                "success": False,
+                "message": "Redis CLI 명령이 시간 초과되었습니다."
+            }, 500
+            
+        except FileNotFoundError:
+            logger.error("redis-cli command not found")
+            return {
+                "success": False,
+                "message": "redis-cli 명령을 찾을 수 없습니다. Redis CLI가 설치되어 있는지 확인해주세요."
+            }, 500
+            
+        except Exception as e:
+            logger.error(f"Unexpected error occurred: {str(e)}")
+            return {
+                "success": False,
+                "message": f"예상치 못한 오류가 발생했습니다: {str(e)}"
+            }, 500


### PR DESCRIPTION
## Summary
- 왼쪽 메뉴에 Trino 버튼 추가하여 대용량 쿼리 처리 시 클러스터 확장 가능
- Redis CLI를 통한 Scale-out 요청 전송 기능 구현
- Admin 권한이 있는 사용자만 접근 가능하도록 권한 제어

## 변경사항
- **Frontend**: 왼쪽 네비게이션에 Trino 메뉴 아이템 및 Scale-out 모달 컴포넌트 추가
- **Backend**: `/api/trino/scaleout` API 엔드포인트 추가
- **기능**: Redis CLI를 통해 Trino 클러스터에 Scale-out 명령 전송

## 테스트 계획
- [ ] 왼쪽 메뉴에 Trino 버튼이 정상적으로 표시되는지 확인
- [ ] Trino 버튼 클릭 시 모달이 정상적으로 열리는지 확인
- [ ] Scale-out 버튼 클릭 시 API 호출이 정상적으로 되는지 확인
- [ ] Admin 권한이 없는 사용자의 접근이 차단되는지 확인
- [ ] Redis CLI 명령이 정상적으로 실행되는지 확인

## 주의사항
- Redis 호스트/포트/채널명을 실제 환경에 맞게 설정 필요
- Redis CLI가 서버에 설치되어 있어야 함