### PR TITLE
DP-2193 redash source 화면에서 Github link menu 를 표시한다.

### DIFF
--- a/client/app/pages/queries/components/QueryPageHeader.jsx
+++ b/client/app/pages/queries/components/QueryPageHeader.jsx
@@ -21,6 +21,7 @@ import useRenameQuery from "../hooks/useRenameQuery";
 import useDuplicateQuery from "../hooks/useDuplicateQuery";
 import useApiKeyDialog from "../hooks/useApiKeyDialog";
 import usePermissionsEditorDialog from "../hooks/usePermissionsEditorDialog";
+import useGitHubLink from "../hooks/useGitHubLink";
 
 import "./QueryPageHeader.less";
 
@@ -81,6 +82,7 @@ export default function QueryPageHeader({
   const [isDuplicating, duplicateQuery] = useDuplicateQuery(query);
   const openApiKeyDialog = useApiKeyDialog(query, onChange);
   const openPermissionsEditorDialog = usePermissionsEditorDialog(query);
+  const { githubUrl, isAvailable: isGitHubLinkAvailable } = useGitHubLink(query.id);
 
   const moreActionsMenu = useMemo(
     () =>
@@ -127,6 +129,16 @@ export default function QueryPageHeader({
             title: "Show API Key",
             onClick: openApiKeyDialog,
           },
+          viewInGitHub: {
+            isAvailable: isGitHubLinkAvailable && !queryFlags.isNew,
+            title: (
+              <React.Fragment>
+                View in GitHub <i className="fa fa-external-link m-l-5" aria-hidden="true" />
+                <span className="sr-only">(opens in a new tab)</span>
+              </React.Fragment>
+            ),
+            onClick: () => window.open(githubUrl, "_blank", "noopener,noreferrer"),
+          },
         },
       ]),
     [
@@ -143,6 +155,8 @@ export default function QueryPageHeader({
       publishQuery,
       unpublishQuery,
       openApiKeyDialog,
+      githubUrl,
+      isGitHubLinkAvailable,
     ]
   );
 

--- a/client/app/pages/queries/hooks/useGitHubLink.js
+++ b/client/app/pages/queries/hooks/useGitHubLink.js
@@ -1,0 +1,73 @@
+import { useState, useEffect, useMemo } from "react";
+import { axios } from "@/services/axios";
+import { clientConfig } from "@/services/auth";
+
+export default function useGitHubLink(queryId) {
+  const [githubUrl, setGithubUrl] = useState(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState(null);
+
+  useEffect(() => {
+    // Don't check if GitHub is not configured or queryId is not valid
+    if (!clientConfig.githubApiToken || !queryId) {
+      setLoading(false);
+      return;
+    }
+
+    // Check cache first
+    const cacheKey = `github_file_${queryId}`;
+    const cached = sessionStorage.getItem(cacheKey);
+    if (cached) {
+      try {
+        const { url, timestamp } = JSON.parse(cached);
+        // Cache valid for 5 minutes
+        if (Date.now() - timestamp < 5 * 60 * 1000) {
+          setGithubUrl(url);
+          setLoading(false);
+          return;
+        }
+      } catch (e) {
+        // Invalid cache, continue to fetch
+        sessionStorage.removeItem(cacheKey);
+      }
+    }
+
+    let cancelRequest = false;
+
+    // Check if file exists
+    axios
+      .get(`api/queries/${queryId}/github_file_exists`)
+      .then(response => {
+        if (!cancelRequest) {
+          if (response.exists && response.url) {
+            setGithubUrl(response.url);
+            // Cache the result
+            sessionStorage.setItem(
+              cacheKey,
+              JSON.stringify({ url: response.url, timestamp: Date.now() })
+            );
+          }
+          setLoading(false);
+        }
+      })
+      .catch(err => {
+        if (!cancelRequest) {
+          setError(err);
+          setLoading(false);
+        }
+      });
+
+    return () => {
+      cancelRequest = true;
+    };
+  }, [queryId]);
+
+  return useMemo(
+    () => ({
+      githubUrl,
+      isLoading: loading,
+      isAvailable: !loading && !error && !!githubUrl,
+    }),
+    [githubUrl, loading, error]
+  );
+}

--- a/redash/handlers/authentication.py
+++ b/redash/handlers/authentication.py
@@ -283,7 +283,7 @@ def client_config():
         "extendedAlertOptions": settings.FEATURE_EXTENDED_ALERT_OPTIONS,
         "mailSettingsMissing": not settings.email_server_is_configured(),
         "dashboardRefreshIntervals": settings.DASHBOARD_REFRESH_INTERVALS,
-        "queryRefreshIntervalFor s": settings.QUERY_REFRESH_INTERVALS,
+        "queryRefreshIntervals": settings.QUERY_REFRESH_INTERVALS,
         "googleLoginEnabled": settings.GOOGLE_OAUTH_ENABLED,
         "ldapLoginEnabled": settings.LDAP_LOGIN_ENABLED,
         "pageSize": settings.PAGE_SIZE,

--- a/redash/handlers/authentication.py
+++ b/redash/handlers/authentication.py
@@ -283,12 +283,15 @@ def client_config():
         "extendedAlertOptions": settings.FEATURE_EXTENDED_ALERT_OPTIONS,
         "mailSettingsMissing": not settings.email_server_is_configured(),
         "dashboardRefreshIntervals": settings.DASHBOARD_REFRESH_INTERVALS,
-        "queryRefreshIntervals": settings.QUERY_REFRESH_INTERVALS,
+        "queryRefreshIntervalFor s": settings.QUERY_REFRESH_INTERVALS,
         "googleLoginEnabled": settings.GOOGLE_OAUTH_ENABLED,
         "ldapLoginEnabled": settings.LDAP_LOGIN_ENABLED,
         "pageSize": settings.PAGE_SIZE,
         "pageSizeOptions": settings.PAGE_SIZE_OPTIONS,
         "tableCellMaxJSONSize": settings.TABLE_CELL_MAX_JSON_SIZE,
+        "githubApiToken": settings.GITHUB_API_TOKEN if settings.GITHUB_API_TOKEN else None,
+        "githubQueriesRepo": settings.GITHUB_QUERIES_REPO,
+        "githubQueriesBranch": settings.GITHUB_QUERIES_BRANCH,
     }
 
     client_config.update(defaults)

--- a/redash/handlers/queries.py
+++ b/redash/handlers/queries.py
@@ -64,6 +64,54 @@ def format_sql_query(org_slug=None):
     return jsonify({"query": sqlparse.format(query, **settings.SQLPARSE_FORMAT_OPTIONS)})
 
 
+@routes.route(org_scoped_rule("/api/queries/<query_id>/github_file_exists"), methods=["GET"])
+@login_required
+@require_permission("view_query")
+def check_github_file_exists(query_id, org_slug=None):
+    """
+    Check if a query file exists in the GitHub repository.
+
+    :param query_id: The query ID
+    :>json bool exists: Whether the file exists
+    :>json string url: The GitHub URL if file exists
+    """
+    if not settings.GITHUB_API_TOKEN:
+        return jsonify({"exists": False, "error": "GitHub API token not configured"})
+
+    try:
+        # Calculate range bucket (1-1000, 1001-2000, etc.)
+        query_id_int = int(query_id)
+        range_start = ((query_id_int - 1) // 1000) * 1000 + 1
+        range_end = range_start + 999
+        range_folder = f"{range_start}-{range_end}"
+
+        # Build file path and GitHub API URL
+        file_path = f"queries/{range_folder}/{query_id}.sql"
+        api_url = f"https://api.github.com/repos/{settings.GITHUB_QUERIES_REPO}/contents/{file_path}?ref={settings.GITHUB_QUERIES_BRANCH}"
+
+        import requests
+
+        headers = {
+            "Authorization": f"token {settings.GITHUB_API_TOKEN}",
+            "Accept": "application/vnd.github.v3+json",
+        }
+        response = requests.get(api_url, headers=headers, timeout=5)
+
+        if response.status_code == 200:
+            github_url = f"https://github.com/{settings.GITHUB_QUERIES_REPO}/blob/{settings.GITHUB_QUERIES_BRANCH}/{file_path}"
+            return jsonify({"exists": True, "url": github_url})
+        else:
+            return jsonify({"exists": False})
+    except ValueError:
+        return jsonify({"exists": False, "error": "Invalid query ID"})
+    except Exception as e:
+        import logging
+
+        logger = logging.getLogger(__name__)
+        logger.exception("Error checking GitHub file existence")
+        return jsonify({"exists": False, "error": str(e)})
+
+
 class QuerySearchResource(BaseResource):
     @require_permission("view_query")
     def get(self):

--- a/redash/settings/__init__.py
+++ b/redash/settings/__init__.py
@@ -52,6 +52,11 @@ QUERY_RESULTS_EXPIRED_TTL = int(os.environ.get("REDASH_QUERY_RESULTS_EXPIRED_TTL
 SCHEMAS_REFRESH_SCHEDULE = int(os.environ.get("REDASH_SCHEMAS_REFRESH_SCHEDULE", 30))
 SCHEMAS_REFRESH_TIMEOUT = int(os.environ.get("REDASH_SCHEMAS_REFRESH_TIMEOUT", 300))
 
+# GitHub API Configuration for query source links
+GITHUB_API_TOKEN = os.environ.get("REDASH_GITHUB_API_TOKEN", "")
+GITHUB_QUERIES_REPO = os.environ.get("REDASH_GITHUB_QUERIES_REPO", "teamdable/dna_redash_queries")
+GITHUB_QUERIES_BRANCH = os.environ.get("REDASH_GITHUB_QUERIES_BRANCH", "main")
+
 AUTH_TYPE = os.environ.get("REDASH_AUTH_TYPE", "api_key")
 INVITATION_TOKEN_MAX_AGE = int(os.environ.get("REDASH_INVITATION_TOKEN_MAX_AGE", 60 * 60 * 24 * 7))
 


### PR DESCRIPTION
## Summary
Adds a "View in GitHub" link in the query page dropdown menu that links to synced SQL files in the dna_redash_queries repository (https://github.com/teamdable/dna_redash_queries).

## Changes

### Backend
- Added GitHub API configuration via environment variables
- Created `/api/queries/<query_id>/github_file_exists` endpoint to verify file existence
- Exposed GitHub config to frontend via `client_config` API

### Frontend
- Created `useGitHubLink` custom React hook with 5-minute sessionStorage cache
- Added "View in GitHub" menu item in query page header dropdown (under "Show API Key")
- Link opens in new tab with external link icon

## Features
- Automatically calculates correct range bucket (e.g., 10574 → 10001-11000)
- Only displays link if file exists (verified via GitHub API)
- Caches results for 5 minutes to reduce API calls
- Only shows for existing queries (not new queries)

## Environment Variables
```bash
REDASH_GITHUB_API_TOKEN=your_github_token_here     # Required
REDASH_GITHUB_QUERIES_REPO=teamdable/dna_redash_queries  # Default
REDASH_GITHUB_QUERIES_BRANCH=main                  # Default
```

## Test Plan
- [x] Query with synced file shows "View in GitHub" link
- [x] Query without synced file hides link
- [x] New queries hide link
- [x] Link opens correct GitHub URL in new tab
- [ ] Manual testing on staging environment

🤖 Generated with [Claude Code](https://claude.com/claude-code)