### PR TITLE
ML-4988 Restrict scheduled query refresh to KST business hours

### DIFF
--- a/redash/settings/__init__.py
+++ b/redash/settings/__init__.py
@@ -430,6 +430,11 @@ FEATURE_ALLOW_CUSTOM_JS_VISUALIZATIONS = parse_boolean(
 FEATURE_AUTO_PUBLISH_NAMED_QUERIES = parse_boolean(os.environ.get("REDASH_FEATURE_AUTO_PUBLISH_NAMED_QUERIES", "true"))
 FEATURE_EXTENDED_ALERT_OPTIONS = parse_boolean(os.environ.get("REDASH_FEATURE_EXTENDED_ALERT_OPTIONS", "false"))
 
+# Business Hours (KST) restriction for scheduled query refresh
+FEATURE_BUSINESS_HOURS_ONLY = parse_boolean(os.environ.get("REDASH_FEATURE_BUSINESS_HOURS_ONLY", "true"))
+BUSINESS_HOURS_START = int(os.environ.get("REDASH_BUSINESS_HOURS_START", "7"))
+BUSINESS_HOURS_END = int(os.environ.get("REDASH_BUSINESS_HOURS_END", "20"))
+
 # BigQuery
 BIGQUERY_HTTP_TIMEOUT = int(os.environ.get("REDASH_BIGQUERY_HTTP_TIMEOUT", "600"))
 

--- a/redash/settings/__init__.py
+++ b/redash/settings/__init__.py
@@ -435,6 +435,9 @@ FEATURE_BUSINESS_HOURS_ONLY = parse_boolean(os.environ.get("REDASH_FEATURE_BUSIN
 BUSINESS_HOURS_START = int(os.environ.get("REDASH_BUSINESS_HOURS_START", "7"))
 BUSINESS_HOURS_END = int(os.environ.get("REDASH_BUSINESS_HOURS_END", "20"))
 
+# Comma-separated query IDs exempt from business hours restriction (e.g. "1,42,100")
+BUSINESS_HOURS_EXEMPT_QUERY_IDS = set_from_string(os.environ.get("REDASH_BUSINESS_HOURS_EXEMPT_QUERY_IDS", ""))
+
 # BigQuery
 BIGQUERY_HTTP_TIMEOUT = int(os.environ.get("REDASH_BIGQUERY_HTTP_TIMEOUT", "600"))
 

--- a/redash/tasks/queries/maintenance.py
+++ b/redash/tasks/queries/maintenance.py
@@ -47,6 +47,9 @@ def _should_refresh_query(query):
     if settings.FEATURE_DISABLE_REFRESH_QUERIES:
         logger.info("Disabled refresh queries.")
         return False
+    elif not _is_within_business_hours() and str(query.id) not in settings.BUSINESS_HOURS_EXEMPT_QUERY_IDS:
+        logger.debug("Skipping refresh of %s because it is outside business hours.", query.id)
+        return False
     elif query.org.is_disabled:
         logger.debug("Skipping refresh of %s because org is disabled.", query.id)
         return False
@@ -95,11 +98,6 @@ def _apply_auto_limit(query_text, query):
 
 
 def refresh_queries():
-    if not _is_within_business_hours():
-        logger.info("Skipping refresh queries: outside KST business hours (%d-%d, Mon-Fri).",
-                     settings.BUSINESS_HOURS_START, settings.BUSINESS_HOURS_END)
-        return
-
     started_at = time.time()
     logger.info("Refreshing queries...")
     enqueued = []

--- a/redash/tasks/queries/maintenance.py
+++ b/redash/tasks/queries/maintenance.py
@@ -1,5 +1,6 @@
 import logging
 import time
+from datetime import datetime, timezone, timedelta
 
 from rq.timeouts import JobTimeoutException
 
@@ -16,6 +17,19 @@ from redash.worker import get_job_logger, job
 from .execution import enqueue_query
 
 logger = get_job_logger(__name__)
+
+KST = timezone(timedelta(hours=9))
+
+
+def _is_within_business_hours():
+    if not settings.FEATURE_BUSINESS_HOURS_ONLY:
+        return True
+    now_kst = datetime.now(KST)
+    if now_kst.weekday() > 4:
+        return False
+    if now_kst.hour < settings.BUSINESS_HOURS_START or now_kst.hour >= settings.BUSINESS_HOURS_END:
+        return False
+    return True
 
 
 def empty_schedules():
@@ -81,6 +95,11 @@ def _apply_auto_limit(query_text, query):
 
 
 def refresh_queries():
+    if not _is_within_business_hours():
+        logger.info("Skipping refresh queries: outside KST business hours (%d-%d, Mon-Fri).",
+                     settings.BUSINESS_HOURS_START, settings.BUSINESS_HOURS_END)
+        return
+
     started_at = time.time()
     logger.info("Refreshing queries...")
     enqueued = []


### PR DESCRIPTION
## Summary
- Restrict scheduled query refresh to KST business hours (Mon-Fri, 7 AM - 8 PM)
- Specific query IDs can be exempted to always run regardless of business hours

## Configuration

All settings are controlled via pod environment variables:

| Env Var | Default | Description |
|---|---|---|
| `REDASH_FEATURE_BUSINESS_HOURS_ONLY` | `true` | Enable/disable business hours restriction. Set `false` to allow all queries at any time. |
| `REDASH_BUSINESS_HOURS_START` | `7` | Start hour (KST, inclusive). Queries won't refresh before this hour. |
| `REDASH_BUSINESS_HOURS_END` | `20` | End hour (KST, exclusive). Queries won't refresh at or after this hour. |
| `REDASH_BUSINESS_HOURS_EXEMPT_QUERY_IDS` | _(empty)_ | Comma-separated query IDs that bypass the business hours restriction (e.g. `"1,42,100"`). |

### Examples

```yaml
# Default: only refresh Mon-Fri 7:00-19:59 KST
REDASH_FEATURE_BUSINESS_HOURS_ONLY: "true"

# Disable restriction entirely (all queries run anytime)
REDASH_FEATURE_BUSINESS_HOURS_ONLY: "false"

# Custom hours: 9 AM - 6 PM KST
REDASH_BUSINESS_HOURS_START: "9"
REDASH_BUSINESS_HOURS_END: "18"

# Exempt specific queries so they run 24/7
REDASH_BUSINESS_HOURS_EXEMPT_QUERY_IDS: "42,100,205"
```

## Test plan
- [x] Deploy with defaults → verify queries only refresh during KST 7-20, Mon-Fri
- [x] Set `REDASH_FEATURE_BUSINESS_HOURS_ONLY=false` → verify queries refresh at any time
- [x] Adjust `REDASH_BUSINESS_HOURS_START` / `REDASH_BUSINESS_HOURS_END` → verify custom boundaries
- [x] Set `REDASH_BUSINESS_HOURS_EXEMPT_QUERY_IDS=42,100` → verify those queries refresh outside business hours while others are blocked

🤖 Generated with [Claude Code](https://claude.com/claude-code)