### PR TITLE
Allow all org members to manage query/dashboard permissions

### DIFF
--- a/client/app/pages/dashboards/components/DashboardHeader.jsx
+++ b/client/app/pages/dashboards/components/DashboardHeader.jsx
@@ -118,7 +118,6 @@ function DashboardMoreOptionsButton({ dashboardConfiguration }) {
     archiveDashboard,
     managePermissions,
     gridDisabled,
-    isDashboardOwnerOrAdmin,
     isDuplicating,
     duplicateDashboard,
   } = dashboardConfiguration;
@@ -152,7 +151,7 @@ function DashboardMoreOptionsButton({ dashboardConfiguration }) {
               </PlainButton>
             </Menu.Item>
           )}
-          {clientConfig.showPermissionsControl && isDashboardOwnerOrAdmin && (
+          {clientConfig.showPermissionsControl && (
             <Menu.Item>
               <PlainButton onClick={managePermissions}>Manage Permissions</PlainButton>
             </Menu.Item>

--- a/client/app/pages/queries/components/QueryPageHeader.jsx
+++ b/client/app/pages/queries/components/QueryPageHeader.jsx
@@ -104,8 +104,7 @@ export default function QueryPageHeader({
             onClick: archiveQuery,
           },
           managePermissions: {
-            isAvailable:
-              !queryFlags.isNew && queryFlags.canEdit && !queryFlags.isArchived && clientConfig.showPermissionsControl,
+            isAvailable: !queryFlags.isNew && !queryFlags.isArchived && clientConfig.showPermissionsControl,
             title: "Manage Permissions",
             onClick: openPermissionsEditorDialog,
           },

--- a/redash/handlers/permissions.py
+++ b/redash/handlers/permissions.py
@@ -6,7 +6,7 @@ from sqlalchemy.orm.exc import NoResultFound
 
 from redash.handlers.base import BaseResource, get_object_or_404
 from redash.models import AccessPermission, Dashboard, Query, User, db
-from redash.permissions import ACCESS_TYPES, require_admin_or_owner
+from redash.permissions import ACCESS_TYPES
 
 model_to_types = {"queries": Query, "dashboards": Dashboard}
 
@@ -36,8 +36,6 @@ class ObjectPermissionsListResource(BaseResource):
     def post(self, object_type, object_id):
         model = get_model_from_type(object_type)
         obj = get_object_or_404(model.get_by_id_and_org, object_id, self.current_org)
-
-        require_admin_or_owner(obj.user_id)
 
         req = request.get_json(True)
 
@@ -69,8 +67,6 @@ class ObjectPermissionsListResource(BaseResource):
     def delete(self, object_type, object_id):
         model = get_model_from_type(object_type)
         obj = get_object_or_404(model.get_by_id_and_org, object_id, self.current_org)
-
-        require_admin_or_owner(obj.user_id)
 
         req = request.get_json(True)
         grantee_id = req["user_id"]

--- a/tests/handlers/test_permissions.py
+++ b/tests/handlers/test_permissions.py
@@ -49,14 +49,17 @@ class TestObjectPermissionsListPost(BaseTestCase):
         self.assertEqual(200, rv.status_code)
         self.assertTrue(AccessPermission.exists(query, ACCESS_TYPE_MODIFY, other_user))
 
-    def test_returns_403_if_the_user_isnt_owner(self):
+    def test_creates_permission_when_the_user_isnt_owner(self):
+        # ACL management is open to any org member, not just owner/admin.
         query = self.factory.create_query()
         other_user = self.factory.create_user()
 
         data = {"access_type": ACCESS_TYPE_MODIFY, "user_id": other_user.id}
 
         rv = self.make_request("post", "/api/queries/{}/acl".format(query.id), user=other_user, data=data)
-        self.assertEqual(403, rv.status_code)
+
+        self.assertEqual(200, rv.status_code)
+        self.assertTrue(AccessPermission.exists(query, ACCESS_TYPE_MODIFY, other_user))
 
     def test_returns_400_if_the_grantee_isnt_from_organization(self):
         query = self.factory.create_query()
@@ -140,14 +143,24 @@ class TestObjectPermissionsListDelete(BaseTestCase):
 
         self.assertEqual(rv.status_code, 404)
 
-    def test_returns_403_for_non_owner(self):
+    def test_removes_permission_as_non_owner(self):
+        # ACL management is open to any org member, not just owner/admin.
         query = self.factory.create_query()
-        user = self.factory.create_user()
+        non_owner = self.factory.create_user()
+        grantee = self.factory.create_user()
 
-        data = {"access_type": ACCESS_TYPE_MODIFY, "user_id": user.id}
-        rv = self.make_request("delete", "/api/queries/{}/acl".format(query.id), user=user, data=data)
+        AccessPermission.grant(
+            obj=query,
+            access_type=ACCESS_TYPE_MODIFY,
+            grantor=self.factory.user,
+            grantee=grantee,
+        )
 
-        self.assertEqual(rv.status_code, 403)
+        data = {"access_type": ACCESS_TYPE_MODIFY, "user_id": grantee.id}
+        rv = self.make_request("delete", "/api/queries/{}/acl".format(query.id), user=non_owner, data=data)
+
+        self.assertEqual(rv.status_code, 200)
+        self.assertFalse(AccessPermission.exists(query, ACCESS_TYPE_MODIFY, grantee))
 
     def test_returns_200_even_if_there_is_no_permission(self):
         query = self.factory.create_query()


### PR DESCRIPTION
## What type of PR is this?

- [x] Feature

## Description

Previously only the owner (author) or an admin could grant/revoke `modify` access through the **Manage Permissions** dialog ("Users with permissions"). This opens it up so that **any logged-in member of the organization** can manage permissions on any query or dashboard.

- `redash/handlers/permissions.py`: removed the `require_admin_or_owner` gate on the ACL `POST`/`DELETE` (`/api/<object_type>/<object_id>/acl`). This endpoint is shared, so the change applies to **both queries and dashboards**.
- `QueryPageHeader.jsx` / `DashboardHeader.jsx`: the "Manage Permissions" menu item is now shown to all members, not just owner/admin (`clientConfig.showPermissionsControl` is still respected).
- Cross-org isolation is **unchanged** — `get_by_id_and_org` still returns 404 for users outside the org, so members can only manage objects within their own organization. Anonymous access remains blocked by `BaseResource`.

Note: a non-owner can now also **revoke** another user's access (including the owner's). This is an accepted trade-off — query/dashboard permission management is not treated as a security boundary here.

## How is this tested?

- [x] Unit tests (pytest)

`tests/handlers/test_permissions.py` updated so non-owner grant/revoke is expected to succeed; the cross-org 404 cases are retained. All 16 tests in the file pass.

The frontend change is a single-condition removal on the menu gate and is not covered by jest/Cypress — verify manually by opening a query/dashboard as a non-owner member and confirming "Manage Permissions" appears and a grant succeeds.

## Related Tickets & Documents

N/A

## Mobile & Desktop Screenshots/Recordings (if there are UI changes)

N/A