### PR TITLE
ML-5958 스케줄 쿼리 matview 증분 refresh + 병합

### DIFF
--- a/.plans/ticketed/ML-5958-matview.md
+++ b/.plans/ticketed/ML-5958-matview.md
@@ -1,0 +1,200 @@
+# ML-5958: Matview 캐쉬 — 스케줄 쿼리 증분 refresh + 병합
+
+Ticket: https://teamdable.atlassian.net/browse/ML-5958
+
+## Goal
+
+스케줄 쿼리가 매 실행마다 전체 기간을 Athena 에서 재스캔하는 것을, 주석 어노테이션 기반으로
+"최근 버킷만 재계산 → 이전 결과와 병합" 하도록 바꾼다. 쿼리 내용이 바뀌면 전체 재적재.
+
+- 대상 예: 쿼리 3742 (60d, day 버킷, 매시간 60일×3테이블 스캔 → 증분 시 ~1일치),
+  10127 (21d, hour 버킷).
+- 저장은 기존 QueryResult 를 그대로 사용 → 대시보드/시각화/API/알림 무변경.
+
+## 쿼리 규약 (작성자 규칙)
+
+1. 첫 줄 주석 어노테이션:
+   ```sql
+   -- matview: bucket_col=utc_basic_time bucket=day retention=60d refresh=4h v=1
+   ```
+   - `bucket`: `day` | `hour` (결과의 버킷 단위)
+   - `refresh`: 이 시간 안의 버킷은 매번 재계산. 최소값 공식: **버킷 값이 최종
+     확정되기까지의 지연 + 스케줄 간격**. 미달이면 kept 와 fresh 사이에 영구 구멍이
+     생긴다. 예: upstream 3h 지연 + 매시간 실행 → 4h (3742); 전방 24h attribution
+     윈도우 + 일간 실행 → 48h (16055).
+   - `v`: 자유 필드. 값을 바꾸면 전체 재적재 (강제 무효화 레버)
+2. fact 테이블 시간 필터 하한은 **마커 + placeholder 리터럴**로, 원래 하한을 `greatest()` 로 유지:
+   ```sql
+   where t1.utc_basic_time >= greatest(/*matview:day*/'1970-01-01',
+         format_datetime(current_timestamp - interval '60' day, 'yyyy-MM-dd'))
+   ```
+   - 마커: `/*matview:day*/'...'` ('yyyy-MM-dd'), `/*matview:hour*/'...'` ('yyyy-MM-dd-HH')
+   - placeholder 는 epoch 고정. 치환 없이 실행해도(에디터, Refresh 버튼) `greatest` 가
+     원래 하한을 고르므로 오늘과 동일한 full-range 쿼리로 동작한다.
+   - `{{ }}` 문법을 쓰지 않는 이유: Redash 파라미터 시스템과 충돌 (스케줄 실행 시
+     default 검증에 걸림).
+3. 결과는 버킷 단위로 분해 가능해야 함: 버킷 밖 데이터로 과거 행이 바뀌는 구조
+   (latest 조인·필터) 금지. 상태는 이력 테이블에서 시점 조인으로 가져올 것.
+4. 상태·디멘전 테이블(작은 것)은 마커 없이 매번 retention 전체를 스캔
+   (버킷 계산에 matview_start 이전 상태가 필요하기도 함).
+
+## 동작 (스케줄 실행 1회 흐름)
+
+```
+matview_hash = md5(Query.query_hash + 어노테이션 문자열)
+meta         = redis GET matview:{query_id}    # {"matview_hash": ...}, TTL 30d
+
+if meta 없음 or meta.matview_hash != matview_hash or latest_query_data 없음:
+    matview_start = now - retention                                   # 전체 로딩
+else:
+    matview_start = bucket_floor(min(now, prev.retrieved_at) - refresh)  # 증분
+    # prev.retrieved_at 기준이라 실행이 몇 번 실패해도 다음 성공 때 공백을 자동 복구
+
+마커 치환 → Athena 실행
+성공 시:
+    kept  = prev rows 중  now-retention ≤ bucket < matview_start      # retention 밀어내기
+    fresh = new  rows 중  bucket ≥ matview_start                      # 이중 카운트 방지 가드
+    data  = kept + fresh                                              # 컬럼 스키마 다르면 병합 포기
+                                                                      #  → redis 키 삭제(다음 주기 full)
+    store_result(...)  → update_latest_result 가 latest 교체
+    redis SET matview:{query_id} {"matview_hash": ...} EX 30d
+실패 시: 저장 안 함 → prev 유지 (다음 성공 실행이 복구)
+```
+
+핵심 불변식: `self.query_hash`/`store_result` 에는 **치환 전 텍스트(템플릿)** 를 그대로 쓴다.
+치환은 runner 에 넘기는 `annotated_query` 로컬 변수에만 적용. `gen_query_hash` 가
+주석·공백을 제거하므로 템플릿 해쉬는 매 실행 동일 → `update_latest_result`(models
+`update_latest_result`, 해쉬 매칭)가 병합 결과를 latest 로 자동 연결하고, enqueue 중복
+방지 락·`get_latest` 캐쉬 조회·알림이 전부 기존 그대로 동작한다. 추가 연결 코드 0줄.
+
+## 삭제 / 수명 관리
+
+| 무엇 | 어떻게 | 코드 |
+|---|---|---|
+| retention 밖 버킷 | 병합 시 새 blob 에 안 실음 (Redash 결과는 실행마다 새 불변 blob이라 행 DELETE 없음) | merge 한 줄 |
+| 옛 result blob (postgres) | 기존 `cleanup_query_results` 가 5분마다, latest 참조가 끊긴 지 7일 지난 blob 을 100개씩 삭제 (`tasks/schedule.py:86`, `maintenance.py:141`). 지금도 매시간 full blob 을 쌓는 구조라 저장 프로필 동일 | 0줄 |
+| 쿼리 내용 변경 시 전체 무효화 | matview_hash 불일치 → full 재적재가 latest 교체 → 옛 blob 은 위 cleanup 이 수거 | plan_window 분기 |
+| redis 메타 키 | TTL 30d, 매 실행 갱신. 쿼리 archive·matview 해제 시 자동 소멸. 유실 = full 재적재 (안전 방향) | SET EX |
+| 강제 재적재 (소스 백필/보정) | ① 어노테이션 `v` 범프 (아래 주의 참고) ② 쿼리 페이지 Refresh 버튼: placeholder 그대로 full-range 실행 → latest 교체, 다음 스케줄 병합 때 retention 트림 | 0줄 |
+
+주의: `gen_query_hash` 는 **주석과 공백을 제거**하므로 주석만 고쳐서는 `Query.query_hash` 가
+안 바뀐다. 그래서 어노테이션 문자열을 matview_hash 에 직접 포함시켜, `v` 범프나
+retention/refresh 변경이 무효화 레버가 되게 한다 (retention 을 늘리면 증분으로는 과거를
+못 채우므로 어노테이션 변경 = full 재적재가 맞는 동작).
+
+## Changes
+
+### 1. `redash/settings/__init__.py`
+
+기존 feature flag 근처에 1줄:
+
+```python
+FEATURE_MATVIEW = parse_boolean(os.environ.get("REDASH_FEATURE_MATVIEW", "true"))
+```
+
+### 2. `redash/utils/matview.py` (신규, ~100줄)
+
+- `parse(query_text) -> MatviewSpec | None` — 첫 부분 주석에서 `-- matview:` 정규식 파싱.
+  flag off 면 None. `MatviewSpec`: bucket_col, bucket, retention, refresh, raw(어노테이션 원문).
+- `plan_window(spec, query_model, redis) -> MatviewCtx` — matview_hash 계산, redis 메타·prev
+  (latest_query_data) 로드, full/증분 결정, matview_start 계산 (버킷 경계 내림).
+- `render(text, matview_start) -> str` — `re.sub(r"/\*matview:(day|hour)\*/'[^']*'", ...)` 치환.
+- `merge(ctx, prev_data, fresh_data) -> data` — 버킷 값 파싱은 ISO datetime /
+  'yyyy-MM-dd-HH' / 'yyyy-MM-dd' 3형식 지원. 컬럼 집합 불일치 시 병합 포기:
+  fresh 만 저장 + redis 키 삭제 + warning 로그 (다음 주기에 full 재적재).
+- `save_meta(redis, query_id, matview_hash)` — TTL 30d.
+
+### 3. `redash/tasks/queries/execution.py` (~20줄)
+
+- `QueryExecutor.__init__`: `models.db.session.close()` (189행) **이전에**
+  matview 준비 — `spec = matview.parse(self.query)`; `self.is_scheduled_query and
+  self.query_model` 일 때만 `self.matview_ctx = matview.plan_window(...)`
+  (prev blob 을 세션 닫기 전에 로드).
+- `run()`: `annotated_query = self._annotate_query(...)` 직후
+  `annotated_query = matview.render(annotated_query, ...)`.
+  성공 분기에서 `store_result` 호출 전 `data = matview.merge(self.matview_ctx, ..., data)`,
+  저장 후 `matview.save_meta(...)`.
+  (`run_query` 반환 data 의 str/dict 여부는 execution.py:224 `_get_size_iterative` 기준
+  구현 시 확인.)
+
+### 4. auto limit 강제 off (2곳, 각 1줄)
+
+matview 쿼리 결과 blob 이 LIMIT 1000 에 잘리면 병합이 통째로 오염되므로 코드에서 차단:
+
+- `redash/tasks/queries/maintenance.py:101` `_apply_auto_limit`:
+  `should_apply_auto_limit = ... and not matview.parse(query_text)`
+- `redash/handlers/query_results.py:76` 동일 가드 (수동 Refresh 가 latest 를 교체하는
+  경로라 여기도 필수).
+
+### 5. 쿼리 마이그레이션 (redash 상 수정, 코드 아님)
+
+**3742** — 어노테이션 `bucket=day retention=60d refresh=4h` + 필터 3곳:
+
+```sql
+-- daily_source
+where t1.utc_basic_time >= greatest(/*matview:day*/'1970-01-01',
+      format_datetime(current_timestamp - interval '60' day, 'yyyy-MM-dd'))
+  and t1.utc_basic_time < format_datetime(current_timestamp - interval '1' day, 'yyyy-MM-dd')
+-- hourly_source
+where t1.utc_basic_time >= greatest(/*matview:hour*/'1970-01-01-00',
+      format_datetime(current_timestamp - interval '1' day, 'yyyy-MM-dd-00'))
+-- d2 (imp_metric_v2_bid_resp_stat_v2 — 현재 hourly 테이블 60일 스캔, 최대 낭비 지점)
+where utc_basic_time >= greatest(/*matview:hour*/'1970-01-01-00',
+      format_datetime(current_timestamp - interval '60' day, 'yyyy-MM-dd-HH'))
+```
+
+알려진 트레이드오프: day D 행은 D+1 04시(UTC) 이후 재계산 안 됨 → fact_daily 버전이
+아니라 hourly 집계 최종본으로 고정. 두 테이블이 동치라는 전제 하에 동일하며, 다르면
+refresh=52h 로 늘려 D−2 시점에 daily 로 한 번 재계산되게 한다.
+
+**10127** — 어노테이션 `bucket=hour retention=21d refresh=4h` + rpm/conv/resp 3곳
+`/*matview:hour*/` 마커. 추가로 tcpa 를 latest 조인 → 시점 조인으로 재작성 (전체 로딩이
+과거 시점 상태를 재현하도록):
+
+```sql
+ctrl as (
+    select client_id, client_company, client_country, utc_basic_time,
+           max(coalesce(dabler_cpa_krw, target_cpa_krw)) as tcpa,
+           max(smart_bidding_on) as smart_bidding_on
+    from ai_craft.dsp_controls__target_cpa_v1
+    where utc_basic_time >= format_datetime(current_timestamp - interval '22' day, 'yyyy-MM-dd-HH')
+    group by 1, 2, 3, 4          -- retention+1d: 첫 버킷의 직전 상태 필요. 마커 없음
+),
+ctrl_range as (
+    select *, utc_basic_time as valid_from,
+           lead(utc_basic_time) over (partition by client_id order by utc_basic_time) as valid_to
+    from ctrl
+)
+-- LEFT JOIN ctrl_range d on a.client_id = d.client_id
+--     and a.utc_basic_time >= d.valid_from
+--     and (d.valid_to is null or a.utc_basic_time < d.valid_to)
+-- WHERE d.smart_bidding_on > 0 and d.tcpa > 0 and d.client_country = 'KR'
+```
+
+`target_client`(최근 7일 실적 필터)는 박제 감수: 증분에서는 계산 시점 기준으로 쌓이고
+(원하는 as-of 의미에 부합), 전체 재적재 때만 현재 기준이 전 기간에 적용된다. 완전한
+시점 재현이 필요해지면 일별 집계 + 윈도우 합으로 시점화한다.
+
+### 6. 적용 후보 검증 결과 (fresh agent 4개 분석, 2026-07-03)
+
+전부 구조 재작성 없이 마커 + 어노테이션만으로 적용 가능. 시점 조인 재작성이 필요했던
+쿼리는 10127 뿐.
+
+| 쿼리 | 결론 | 어노테이션 | 마커 | 비고 |
+|---|---|---|---|---|
+| 14986 tRoAS Lever Daily | 적합 | `bucket_col=utc_date bucket=day retention=90d refresh=4h` | hour×1 | schedule=null → Redash 스케줄 등록해야 증분 경로를 탐. latest 디멘전 3곳 박제 감수. 스캔 ~1/45 (raw_request 대형 컬럼, ~$5→~$0.1/회) |
+| 6878 cpa base - models | 적합 | `bucket_col=utc_date bucket=day retention=21d refresh=4h` | hour×2 | 상태 조인 3곳(서비스 셋·롤링 캠페인 셋·client명) 박제 감수. auto_limit=true → §4 가드 필수. conv 포스트백 지연 확인 후 필요시 refresh=28h. 스캔 90–95%↓ |
+| 22907 line today widget | 적합 | `bucket_col=bucket_time bucket=day retention=31d refresh=4h` | day×1, hour×1 | `day_clk>50` 일 단위 윈도우 필터 → **bucket=day 필수** (hour 선언 시 당일 초반 행 영구 유실). 증분 정착 후 과거 일자가 hourly 24행으로 박제(값 동일, full 재적재 시 daily 1행으로 collapse) |
+| 16055 audience_business_base | 적합 (조건) | `bucket_col=utc_basic_time bucket=hour retention=30d refresh=48h` | hour×3 (airbridge 1곳 1d 패드) | 일간 스케줄 + 버킷 값이 [H, H+23h] 전방 윈도우로 확정 → **refresh=48h 필수** (규약 1 공식). 결과 ~4.6만 행 → §4 가드 실질 필요. airbridge 파티션 의미(터치 vs 적재) 적용 전 1회 확인. 스캔 ~1/10 |
+
+## Verification
+
+1. unit (`tests/test_matview.py`): parse(어노테이션 변형/미존재), render(마커 치환·placeholder
+   보존), merge(retention 컷, matview_start 컷, fresh 가드, 3가지 버킷 형식, 스키마 불일치),
+   plan_window(메타 없음/불일치/prev 없음 → full; retrieved_at 기반 self-healing).
+2. 로컬 compose: matview 쿼리 스케줄 2회 실행 — 1회차 full + redis 키 생성, 2회차 증분
+   (Athena 로그로 치환 확인, 결과 = full 실행과 동일), 텍스트·`v` 수정 → full 재적재.
+3. 운영: 3742 에 적용 후 Athena 실행 이력(S3 저장, ML-5275)으로 scanned bytes 비교
+   (기대: 시간당 60일×3테이블 → ~1일치, 1/30 이하). 하루 뒤 최고(最古) 버킷이 하나씩
+   빠지는지, D−1/D 버킷 값이 full 재실행과 일치하는지 spot check.
+4. 배포: README 절차로 이미지 `25.8.0-Dable-0.0.8` 빌드·푸시.

--- a/.plans/ticketed/ML-5958-matview.md
+++ b/.plans/ticketed/ML-5958-matview.md
@@ -62,8 +62,8 @@ else:
 ```
 
 핵심 불변식: `self.query_hash`/`store_result` 에는 **치환 전 텍스트(템플릿)** 를 그대로 쓴다.
-치환은 runner 에 넘기는 `annotated_query` 로컬 변수에만 적용. `gen_query_hash` 가
-주석·공백을 제거하므로 템플릿 해쉬는 매 실행 동일 → `update_latest_result`(models
+치환은 runner 에 넘기는 `annotated_query` 로컬 변수에만 적용. 템플릿은 매 실행 동일한
+텍스트이므로 해쉬도 동일 → `update_latest_result`(models
 `update_latest_result`, 해쉬 매칭)가 병합 결과를 latest 로 자동 연결하고, enqueue 중복
 방지 락·`get_latest` 캐쉬 조회·알림이 전부 기존 그대로 동작한다. 추가 연결 코드 0줄.
 
@@ -77,10 +77,12 @@ else:
 | redis 메타 키 | TTL 30d, 매 실행 갱신. 쿼리 archive·matview 해제 시 자동 소멸. 유실 = full 재적재 (안전 방향) | SET EX |
 | 강제 재적재 (소스 백필/보정) | ① 어노테이션 `v` 범프 (아래 주의 참고) ② 쿼리 페이지 Refresh 버튼: placeholder 그대로 full-range 실행 → latest 교체, 다음 스케줄 병합 때 retention 트림 | 0줄 |
 
-주의: `gen_query_hash` 는 **주석과 공백을 제거**하므로 주석만 고쳐서는 `Query.query_hash` 가
-안 바뀐다. 그래서 어노테이션 문자열을 matview_hash 에 직접 포함시켜, `v` 범프나
-retention/refresh 변경이 무효화 레버가 되게 한다 (retention 을 늘리면 증분으로는 과거를
-못 채우므로 어노테이션 변경 = full 재적재가 맞는 동작).
+주의(구현 시 확인): `gen_query_hash` 는 블록 주석(`/* */`)과 공백만 제거하고 `--` 줄 주석은
+해쉬에 포함된다 (`utils/__init__.py` COMMENTS_REGEX). 따라서 어노테이션(`--` 줄) 수정만으로도
+`Query.query_hash` 가 바뀌어 full 재적재가 된다. 어노테이션 문자열을 matview_hash 에 직접
+포함시키는 것은 이중 안전장치로 유지 (retention 을 늘리면 증분으로는 과거를 못 채우므로
+어노테이션 변경 = full 재적재가 맞는 동작). 마커는 블록 주석이라 해쉬에서 제거되지만
+placeholder 리터럴은 남는다 — 템플릿이 고정이므로 매 실행 동일, 문제 없음.
 
 ## Changes
 
@@ -99,7 +101,8 @@ FEATURE_MATVIEW = parse_boolean(os.environ.get("REDASH_FEATURE_MATVIEW", "true")
 - `plan_window(spec, query_model, redis) -> MatviewCtx` — matview_hash 계산, redis 메타·prev
   (latest_query_data) 로드, full/증분 결정, matview_start 계산 (버킷 경계 내림).
 - `render(text, matview_start) -> str` — `re.sub(r"/\*matview:(day|hour)\*/'[^']*'", ...)` 치환.
-- `merge(ctx, prev_data, fresh_data) -> data` — 버킷 값 파싱은 ISO datetime /
+- `merge(ctx, data, redis) -> data` (prev rows 는 ctx 에, redis 는 give-up 시 메타 키 삭제용) —
+  버킷 값 파싱은 ISO datetime /
   'yyyy-MM-dd-HH' / 'yyyy-MM-dd' 3형식 지원. 컬럼 집합 불일치 시 병합 포기:
   fresh 만 저장 + redis 키 삭제 + warning 로그 (다음 주기에 full 재적재).
 - `save_meta(redis, query_id, matview_hash)` — TTL 30d.
@@ -112,7 +115,7 @@ FEATURE_MATVIEW = parse_boolean(os.environ.get("REDASH_FEATURE_MATVIEW", "true")
   (prev blob 을 세션 닫기 전에 로드).
 - `run()`: `annotated_query = self._annotate_query(...)` 직후
   `annotated_query = matview.render(annotated_query, ...)`.
-  성공 분기에서 `store_result` 호출 전 `data = matview.merge(self.matview_ctx, ..., data)`,
+  성공 분기에서 `store_result` 호출 전 `data = matview.merge(self.matview_ctx, data, redis_connection)`,
   저장 후 `matview.save_meta(...)`.
   (`run_query` 반환 data 의 str/dict 여부는 execution.py:224 `_get_size_iterative` 기준
   구현 시 확인.)
@@ -194,6 +197,70 @@ ctrl_range as (
    plan_window(메타 없음/불일치/prev 없음 → full; retrieved_at 기반 self-healing).
 2. 로컬 compose: matview 쿼리 스케줄 2회 실행 — 1회차 full + redis 키 생성, 2회차 증분
    (Athena 로그로 치환 확인, 결과 = full 실행과 동일), 텍스트·`v` 수정 → full 재적재.
+   - 시나리오: 3742 의 5d 변형(60d→5d, 마커 3곳 — daily day×1, hourly hour×1, d2 hour×1,
+     `apply_auto_limit=true` 유지해 auto limit 가드도 검증) 을 schedule 1h 로 등록,
+     다음날 어노테이션·마커 없는 plain 5d 쿼리와 결과 비교. D−2 이전 버킷 불일치는
+     fact_daily vs hourly 집계 차이(§5 트레이드오프)일 수 있으므로 두 테이블 동치 확인.
+
+   ```sql
+   -- matview: bucket_col=utc_basic_time bucket=day retention=5d refresh=4h v=1
+   ```
+   - 검증 스택 `compose.matview-verify.yaml` (리포 루트, untracked — 이미지는
+     `podman build -t redash-matview:local .` arm64 네이티브, 프론트 포함):
+
+   ```yaml
+   x-env: &env
+     REDASH_LOG_LEVEL: "INFO"
+     REDASH_REDIS_URL: "redis://redis:6379/0"
+     REDASH_DATABASE_URL: "postgresql://postgres@postgres/postgres"
+     REDASH_RATELIMIT_ENABLED: "false"
+     REDASH_FEATURE_BUSINESS_HOURS_ONLY: "false"
+     REDASH_COOKIE_SECRET: "<openssl rand -hex 16>"
+     REDASH_SECRET_KEY: "<openssl rand -hex 16>"
+
+   services:
+     server:
+       image: localhost/redash-matview:local
+       command: server
+       depends_on: [postgres, redis]
+       ports:
+         - "5001:5000"
+       environment: *env
+       restart: unless-stopped
+     scheduler:
+       image: localhost/redash-matview:local
+       command: scheduler
+       depends_on: [server]
+       environment: *env
+       restart: unless-stopped
+     worker:
+       image: localhost/redash-matview:local
+       command: worker
+       depends_on: [server]
+       environment:
+         <<: *env
+         QUEUES: ""
+         WORKERS_COUNT: "2"
+       restart: unless-stopped
+     redis:
+       image: docker.io/library/redis:7-alpine
+       restart: unless-stopped
+     postgres:
+       image: docker.io/library/postgres:13-alpine
+       environment:
+         POSTGRES_HOST_AUTH_METHOD: "trust"
+       volumes:
+         - matview-pg:/var/lib/postgresql/data
+       restart: unless-stopped
+
+   volumes:
+     matview-pg:
+   ```
+
+   - 초기화: `podman compose -f compose.matview-verify.yaml up -d` →
+     `run --rm server create_db` → `exec server ./manage.py users create_root ...` →
+     API 로 Athena DS(운영 DS 5 와 동일 옵션 + 로컬 AWS 키)·쿼리 등록.
+     Athena 실행이력 S3 업로드는 `ATHENA_EXECUTION_HISTORY_S3_PATH` 미설정으로 자동 off.
 3. 운영: 3742 에 적용 후 Athena 실행 이력(S3 저장, ML-5275)으로 scanned bytes 비교
    (기대: 시간당 60일×3테이블 → ~1일치, 1/30 이하). 하루 뒤 최고(最古) 버킷이 하나씩
    빠지는지, D−1/D 버킷 값이 full 재실행과 일치하는지 spot check.

--- a/matview_manual.md
+++ b/matview_manual.md
@@ -1,0 +1,109 @@
+# Matview 매뉴얼 (LLM용)
+
+Redash 쿼리에 matview(증분 캐쉬)를 판정·적용할 때 이 문서만으로 작업한다.
+설계 배경·구현 내부는 `.plans/ticketed/ML-5958-matview.md` (https://teamdable.atlassian.net/browse/ML-5958).
+
+## 동작 모델 (판단에 필요한 만큼만)
+
+- 스케줄 실행마다: `matview_start = 버킷경계내림(min(now, 직전결과시각) − refresh)`.
+  쿼리를 matview_start 이후 범위로만 실행해 새 행을 얻고, 직전 결과에서
+  `[now − retention, matview_start)` 행을 그대로 유지해 이어붙인다.
+- full 재적재(전 기간 재실행) 조건: 첫 실행 / SQL 본문 변경(주석·공백 제외한 해쉬) /
+  어노테이션 문자열 변경(`v` 범프 포함) / 결과 컬럼 집합 변경 / 쿼리 페이지 Refresh 버튼.
+- 함의: **matview_start 이전 버킷은 다시 계산되지 않는다.** 과거 버킷은 그 버킷이
+  마지막으로 재계산된 시점의 데이터·조인 상태로 고정된다(박제). 판정의 대부분은
+  "이 박제가 쿼리 의미를 깨는가"를 묻는 일이다.
+
+## 적용 판정 절차
+
+1. **버킷 식별**: 모든 출력 행이 정확히 하나의 시간 버킷에 귀속되는 컬럼을 찾는다.
+   값 형식은 ISO datetime / `'yyyy-MM-dd'` / `'yyyy-MM-dd-HH'` 만 지원. 없으면 부적합.
+2. **버킷 분해성 검사** — 다음 구조를 전부 찾아 표시한다:
+   - 전 기간 집계(GROUP BY 에 버킷 없음), 버킷 경계를 넘는 윈도우 함수
+     → bucket 단위를 키우면 해소되는지 확인 (일 단위 `PARTITION BY date(...)` 윈도우
+     → `bucket=day` 로 선언하면 안전; hour 로 선언하면 당일 초반 행이 잘못 박제됨)
+   - latest 상태 조인/필터 → 아래 "상태 조인 3-way"
+   - 롤링 윈도우 기준 필터(최근 N일 실적으로 대상 선정 등) → 박제 감수 또는 시점화
+   - 전방(미래) 윈도우 지표: 버킷 H 의 값이 H 이후 데이터로 확정(attribution 등)
+     → refresh 를 확정 지연만큼 키워 흡수
+3. **판정**: 적합 / 조건부(무엇을 바꿔야) / 부적합(이유). 근거를 함께 쓴다.
+
+## 변환 규칙
+
+1. **어노테이션** — 쿼리 최상단 주석 1줄:
+   ```sql
+   -- matview: bucket_col=<컬럼> bucket=<day|hour> retention=<N>d refresh=<N>h v=1
+   ```
+   - `retention`: 현재 쿼리의 조회 기간 그대로.
+   - `refresh` 최소값 공식 = **버킷 값이 최종 확정되기까지의 지연 + 스케줄 간격**.
+     미달이면 유지분과 새 계산분 사이에 영구 구멍이 생긴다.
+     예: upstream 확정 3h + 매시간 실행 → 4h / 전환이 하루쯤 소급되는 지표 → 28h /
+     전방 24h attribution 윈도우 + 일간 실행 → 48h.
+   - `v`: 자유 필드. 값 변경 = 강제 full 재적재 레버.
+2. **마커** — fact 테이블(시간 파티션 필터가 있는 큰 테이블)의 **시간 하한에만**:
+   ```sql
+   -- 변경 전
+   where utc_basic_time >= format_datetime(current_timestamp - interval '60' day, 'yyyy-MM-dd')
+   -- 변경 후
+   where utc_basic_time >= greatest(/*matview:day*/'1970-01-01',
+         format_datetime(current_timestamp - interval '60' day, 'yyyy-MM-dd'))
+   ```
+   - 파티션 형식이 `'yyyy-MM-dd-HH'` 면 `/*matview:hour*/'1970-01-01-00'`.
+   - **원래 하한을 반드시 `greatest()` 로 보존**한다. 치환 없이 실행돼도(에디터,
+     Refresh 버튼) placeholder 가 epoch 라 원래 하한이 선택되어 full-range 로 동작해야 한다.
+   - 상한과 JOIN 조건은 손대지 않는다.
+   - 파티션 시각이 버킷 시각보다 앞설 수 있는 테이블(적재 시각 파티션 등)은 마커 값을
+     패드한다: `date_add('day', -1, date_parse(/*matview:hour*/'1970-01-01-00', '%Y-%m-%d-%H'))` 꼴.
+3. **마커 제외 대상**: 상태·디멘전 테이블(`__latest`, 컨트롤/메타, 인라인 VALUES).
+   작고, 버킷 계산에 matview_start 이전 상태가 필요할 수 있으므로 매번 전체(또는
+   retention+여유) 스캔을 유지한다.
+4. `{{ }}` 파라미터 문법은 쓰지 않는다 (Redash 파라미터 시스템과 충돌).
+
+## 상태 조인 3-way 판정
+
+버킷 밖 데이터(현재 상태)가 행의 값·포함 여부에 영향을 주는 조인/필터마다:
+
+- **(a) 박제 감수**: 속성이 사실상 불변(생성 시 고정 매핑, 디멘전 이름, OS 등)이거나,
+  "그 시점 기준" 박제가 오히려 의도(as-of)에 맞는 경우. 그대로 두고 판정에 명시한다.
+  full 재적재 때만 현재 상태가 전 기간에 소급됨을 함께 명시.
+- **(b) 시점 조인 재작성**: 과거 행의 포함 여부·값이 현재 상태로 결정되면 안 되고,
+  상태의 이력 테이블이 존재하는 경우. latest 선택을 유효 구간 조인으로 바꾼다:
+  ```sql
+  ctrl as (  -- (client, 시각) 중복 스냅샷 먼저 접기
+      select client_id, utc_basic_time, max(value) as value
+      from history_table
+      where utc_basic_time >= format_datetime(current_timestamp - interval '<retention+1>' day, 'yyyy-MM-dd-HH')
+      group by 1, 2
+  ),
+  ctrl_range as (
+      select *, utc_basic_time as valid_from,
+             lead(utc_basic_time) over (partition by client_id order by utc_basic_time) as valid_to
+      from ctrl
+  )
+  -- JOIN: a.utc_basic_time >= d.valid_from and (d.valid_to is null or a.utc_basic_time < d.valid_to)
+  ```
+  이력 스캔은 retention+1d (첫 버킷의 직전 상태가 필요). 마커 없음.
+- **(c) 부적합**: 이력 테이블이 없는데 박제도 허용 못 하는 경우. matview 포기 또는
+  상태 필터를 결과 컬럼으로 내려 시각화에서 거르도록 제안.
+
+## 함정 체크리스트
+
+- 윈도우 함수의 partition 범위가 버킷 안에 갇히는가? 일 단위 윈도우면 `bucket=day` 필수.
+- daily+hourly 핸드오프 쿼리(과거는 daily 테이블, 최근은 hourly 집계): 증분에서는
+  daily 소스가 다시 읽히지 않아 각 일자가 hourly 집계 최종본으로 고정된다.
+  두 테이블이 무손실 롤업 관계라는 전제를 판정에 명시. 아니면 refresh 를 핸드오프
+  경계 너머로(예: 52h) 키워 daily 로 한 번 재계산되게 한다.
+- 최종 `ORDER BY`: 병합(유지분+새 행 이어붙임) 후 전역 정렬이 깨진다. 시각화가 자체
+  정렬하면 무해 — 아니라면 주의로 명시.
+- `apply_auto_limit`: matview 경로는 코드가 강제 off. 지금까지 LIMIT 1000 에 잘리던
+  쿼리는 전환 후 행수가 늘어난다 — 판정에 명시.
+- 스케줄 없는 쿼리는 증분 경로를 타지 않는다(비스케줄 실행 = full-range). 절감을
+  받으려면 Redash 스케줄 등록이 선행돼야 함을 명시.
+- 하드코딩 리스트/VALUES 변경은 SQL 해쉬 변경 → 자동 full 재적재. 별도 조치 불요.
+
+## 작업 출력 형식
+
+- **분석 요청**: 결론(적합/조건부/부적합) · 버킷(컬럼/단위/형식) · 어노테이션 제안 ·
+  마커 적용 지점(바뀌는 줄만) · 상태 조인 판정 · 예상 절감(현재 스캔 기간·테이블 수
+  대비) · 주의(스케줄, auto_limit, 특이점).
+- **변환 요청**: 어노테이션 1줄 + 바뀌는 필터 줄만. 전체 SQL 재출력은 요청받았을 때만.

--- a/redash/handlers/query_results.py
+++ b/redash/handlers/query_results.py
@@ -33,6 +33,7 @@ from redash.tasks.queries import enqueue_query
 from redash.utils import (
     collect_parameters_from_request,
     json_dumps,
+    matview,
     to_filename,
 )
 
@@ -73,6 +74,8 @@ def run_query(query, parameters, data_source, query_id, should_apply_auto_limit,
     except (InvalidParameterError, QueryDetachedFromDataSourceError) as e:
         abort(400, message=str(e))
 
+    # matview merge needs the complete result; a truncating LIMIT would poison the blob
+    should_apply_auto_limit = should_apply_auto_limit and not matview.parse(query.text)
     query_text = data_source.query_runner.apply_auto_limit(query.text, should_apply_auto_limit)
 
     if query.missing_params:

--- a/redash/settings/__init__.py
+++ b/redash/settings/__init__.py
@@ -438,6 +438,9 @@ BUSINESS_HOURS_END = int(os.environ.get("REDASH_BUSINESS_HOURS_END", "20"))
 # Comma-separated query IDs exempt from business hours restriction (e.g. "1,42,100")
 BUSINESS_HOURS_EXEMPT_QUERY_IDS = set_from_string(os.environ.get("REDASH_BUSINESS_HOURS_EXEMPT_QUERY_IDS", ""))
 
+# Incremental refresh of scheduled queries via "-- matview:" annotation (ML-5958)
+FEATURE_MATVIEW = parse_boolean(os.environ.get("REDASH_FEATURE_MATVIEW", "true"))
+
 # BigQuery
 BIGQUERY_HTTP_TIMEOUT = int(os.environ.get("REDASH_BIGQUERY_HTTP_TIMEOUT", "600"))
 

--- a/redash/tasks/queries/execution.py
+++ b/redash/tasks/queries/execution.py
@@ -14,7 +14,7 @@ from redash.query_runner import InterruptException
 from redash.tasks.alerts import check_alerts_for_query
 from redash.tasks.failure_report import track_failure
 from redash.tasks.worker import Job, Queue
-from redash.utils import gen_query_hash, utcnow
+from redash.utils import gen_query_hash, matview, utcnow
 from redash.worker import get_job_logger
 
 logger = get_job_logger(__name__)
@@ -186,6 +186,13 @@ class QueryExecutor:
             else None
         )  # fmt: skip
 
+        self.matview_ctx = None
+        if is_scheduled_query and self.query_model:
+            spec = matview.parse(self.query)
+            if spec:
+                # Loads the previous result blob; must happen before the session close below.
+                self.matview_ctx = matview.plan_window(spec, self.query_model, redis_connection)
+
         # Close DB connection to prevent holding a connection for a long time while the query is executing.
         models.db.session.close()
         self.query_hash = gen_query_hash(self.query)
@@ -203,6 +210,8 @@ class QueryExecutor:
 
         query_runner = self.data_source.query_runner
         annotated_query = self._annotate_query(query_runner)
+        if self.matview_ctx:
+            annotated_query = matview.render(annotated_query, self.matview_ctx.matview_start)
 
         try:
             data, error = query_runner.run_query(annotated_query, self.user)
@@ -240,11 +249,14 @@ class QueryExecutor:
                 self.query_model.skip_updated_at = True
                 models.db.session.add(self.query_model)
 
+            if self.matview_ctx:
+                data = matview.merge(self.matview_ctx, data, redis_connection)
+
             query_result = models.QueryResult.store_result(
                 self.data_source.org_id,
                 self.data_source,
                 self.query_hash,
-                self.query,
+                self.query,  # matview: always the un-rendered template, so the hash stays stable
                 data,
                 run_time,
                 utcnow(),
@@ -253,6 +265,8 @@ class QueryExecutor:
             updated_query_ids = models.Query.update_latest_result(query_result)
 
             models.db.session.commit()  # make sure that alert sees the latest query result
+            if self.matview_ctx and not self.matview_ctx.aborted:
+                matview.save_meta(redis_connection, self.query_id, self.matview_ctx.matview_hash)
             self._log_progress("checking_alerts")
             for query_id in updated_query_ids:
                 check_alerts_for_query.delay(query_id, self.metadata)

--- a/redash/tasks/queries/maintenance.py
+++ b/redash/tasks/queries/maintenance.py
@@ -1,9 +1,8 @@
 import logging
 import time
-from datetime import datetime, timezone, timedelta
+from datetime import datetime, timedelta, timezone
 
 import holidays
-
 from rq.timeouts import JobTimeoutException
 
 from redash import models, redis_connection, settings, statsd_client
@@ -13,7 +12,7 @@ from redash.models.parameterized_query import (
 )
 from redash.monitor import rq_job_ids
 from redash.tasks.failure_report import track_failure
-from redash.utils import json_dumps, sentry
+from redash.utils import json_dumps, matview, sentry
 from redash.worker import get_job_logger, job
 
 from .execution import enqueue_query
@@ -98,7 +97,8 @@ class RefreshQueriesError(Exception):
 
 
 def _apply_auto_limit(query_text, query):
-    should_apply_auto_limit = query.options.get("apply_auto_limit", False)
+    # matview merge needs the complete result; a truncating LIMIT would poison the blob
+    should_apply_auto_limit = query.options.get("apply_auto_limit", False) and not matview.parse(query_text)
     return query.data_source.query_runner.apply_auto_limit(query_text, should_apply_auto_limit)
 
 

--- a/redash/utils/matview.py
+++ b/redash/utils/matview.py
@@ -1,0 +1,219 @@
+"""Incremental refresh ("matview") for scheduled queries — ML-5958.
+
+A query opts in with a leading comment annotation:
+
+    -- matview: bucket_col=utc_basic_time bucket=day retention=60d refresh=4h v=1
+
+and marks fact-table time filters with placeholder literals kept inside greatest():
+
+    where t >= greatest(/*matview:day*/'1970-01-01', <original lower bound>)
+
+On scheduled runs only the recent window (refresh) is recomputed and merged with
+the previous result rows; the stored query text/hash stays the un-rendered
+template so latest-result linking, locks and alerts work unchanged.
+See .plans/ticketed/ML-5958-matview.md for the full design.
+"""
+
+import hashlib
+import logging
+import re
+from dataclasses import dataclass
+from datetime import datetime, timedelta, timezone
+
+from redash import settings
+from redash.utils import json_dumps, json_loads, utcnow
+
+logger = logging.getLogger(__name__)
+
+ANNOTATION_RE = re.compile(r"^\s*--\s*matview:\s*(.+?)\s*$")
+MARKER_RE = re.compile(r"(/\*matview:(day|hour)\*/)\s*'[^']*'")
+DURATION_RE = re.compile(r"^(\d+)([dh])$")
+BUCKET_FORMATS = {"day": "%Y-%m-%d", "hour": "%Y-%m-%d-%H"}
+META_KEY = "matview:{}"
+META_TTL = 60 * 60 * 24 * 30  # queries archived or de-annotated fade out on their own
+
+
+@dataclass
+class MatviewSpec:
+    bucket_col: str
+    bucket: str  # "day" | "hour"
+    retention: timedelta
+    refresh: timedelta
+    raw: str  # annotation line as written; part of matview_hash so edits force a full reload
+
+
+@dataclass
+class MatviewCtx:
+    spec: MatviewSpec
+    query_id: int
+    matview_hash: str
+    full: bool
+    matview_start: datetime  # naive UTC, bucket-floored; buckets >= this are recomputed
+    retention_start: datetime  # naive UTC, bucket-floored; prev buckets < this are dropped
+    prev_rows: list
+    prev_columns: list
+    aborted: bool = False  # merge gave up; meta must not be saved
+
+
+def parse(query_text):
+    """Return MatviewSpec if the query's leading comment lines carry an annotation, else None."""
+    if not settings.FEATURE_MATVIEW or not query_text:
+        return None
+    for line in query_text.splitlines():
+        stripped = line.strip()
+        if not stripped:
+            continue
+        if not stripped.startswith("--"):
+            return None  # annotation must precede the query body
+        match = ANNOTATION_RE.match(line)
+        if not match:
+            continue
+        try:
+            fields = dict(kv.split("=", 1) for kv in match.group(1).split())
+            if fields["bucket"] not in BUCKET_FORMATS:
+                raise ValueError("bucket=%s" % fields["bucket"])
+            return MatviewSpec(
+                bucket_col=fields["bucket_col"],
+                bucket=fields["bucket"],
+                retention=_parse_duration(fields["retention"]),
+                refresh=_parse_duration(fields["refresh"]),
+                raw=stripped,
+            )
+        except (KeyError, ValueError) as e:
+            # Malformed annotation: run the query untouched (placeholders keep it full-range).
+            logger.warning("matview: ignoring malformed annotation %r (%r)", stripped, e)
+            return None
+    return None
+
+
+def plan_window(spec, query_model, redis, now=None):
+    """Decide full vs incremental and load prev rows. Call while the DB session is open."""
+    now = _utc_naive(now or utcnow())
+    matview_hash = hashlib.md5(
+        (query_model.query_hash + spec.raw).encode("utf-8"), usedforsecurity=False
+    ).hexdigest()
+
+    meta = redis.get(META_KEY.format(query_model.id))
+    meta_hash = json_loads(meta).get("matview_hash") if meta else None
+    prev = query_model.latest_query_data
+    prev_data = prev.data if prev else None
+    if isinstance(prev_data, str):
+        prev_data = json_loads(prev_data)
+
+    if meta_hash != matview_hash or not prev_data:
+        full = True
+        matview_start = now - spec.retention
+        prev_rows, prev_columns = [], []
+    else:
+        full = False
+        # min() guards against clock skew; retrieved_at base self-heals gaps after failed runs
+        matview_start = min(now, _utc_naive(prev.retrieved_at)) - spec.refresh
+        prev_rows = prev_data.get("rows", [])
+        prev_columns = prev_data.get("columns", [])
+
+    ctx = MatviewCtx(
+        spec=spec,
+        query_id=query_model.id,
+        matview_hash=matview_hash,
+        full=full,
+        matview_start=_bucket_floor(matview_start, spec.bucket),
+        retention_start=_bucket_floor(now - spec.retention, spec.bucket),
+        prev_rows=prev_rows,
+        prev_columns=prev_columns,
+    )
+    logger.info(
+        "matview: query=%s mode=%s matview_start=%s prev_rows=%d",
+        ctx.query_id,
+        "full" if full else "incremental",
+        ctx.matview_start,
+        len(prev_rows),
+    )
+    return ctx
+
+
+def render(query_text, matview_start):
+    """Replace /*matview:day|hour*/'...' placeholder literals with the window start."""
+
+    def repl(match):
+        return "%s'%s'" % (match.group(1), matview_start.strftime(BUCKET_FORMATS[match.group(2)]))
+
+    return MARKER_RE.sub(repl, query_text)
+
+
+def merge(ctx, data, redis):
+    """Combine kept prev rows with fresh rows into the new result data.
+
+    On any inconsistency (schema change, unparseable bucket) give up: store fresh
+    rows only and drop the redis meta so the next run does a full reload.
+    """
+    if isinstance(data, str):
+        data = json_loads(data)
+    if ctx.full:
+        return data
+
+    if sorted(c["name"] for c in data.get("columns", [])) != sorted(c["name"] for c in ctx.prev_columns):
+        return _give_up(ctx, data, redis, "column schema changed")
+
+    col = ctx.spec.bucket_col
+    try:
+        kept = [row for row in ctx.prev_rows if ctx.retention_start <= _parse_bucket(row[col]) < ctx.matview_start]
+        fresh = [row for row in data.get("rows", []) if _parse_bucket(row[col]) >= ctx.matview_start]
+    except (KeyError, TypeError, ValueError) as e:
+        return _give_up(ctx, data, redis, "bad bucket value (%r)" % e)
+
+    logger.info(
+        "matview: query=%s merged kept=%d fresh=%d prev=%d",
+        ctx.query_id,
+        len(kept),
+        len(fresh),
+        len(ctx.prev_rows),
+    )
+    data["rows"] = kept + fresh
+    return data
+
+
+def save_meta(redis, query_id, matview_hash):
+    redis.setex(META_KEY.format(query_id), META_TTL, json_dumps({"matview_hash": matview_hash}))
+
+
+def _give_up(ctx, data, redis, reason):
+    logger.warning(
+        "matview: query=%s merge aborted (%s); storing fresh rows only, next run reloads fully",
+        ctx.query_id,
+        reason,
+    )
+    ctx.aborted = True
+    redis.delete(META_KEY.format(ctx.query_id))
+    return data
+
+
+def _parse_duration(value):
+    match = DURATION_RE.match(value)
+    if not match:
+        raise ValueError(value)
+    count, unit = int(match.group(1)), match.group(2)
+    return timedelta(days=count) if unit == "d" else timedelta(hours=count)
+
+
+def _bucket_floor(dt, bucket):
+    if bucket == "day":
+        return dt.replace(hour=0, minute=0, second=0, microsecond=0)
+    return dt.replace(minute=0, second=0, microsecond=0)
+
+
+def _utc_naive(dt):
+    if dt.tzinfo:
+        return dt.astimezone(timezone.utc).replace(tzinfo=None)
+    return dt
+
+
+def _parse_bucket(value):
+    if isinstance(value, datetime):
+        return _utc_naive(value)
+    text = str(value)
+    for fmt in (BUCKET_FORMATS["hour"], BUCKET_FORMATS["day"]):
+        try:
+            return datetime.strptime(text, fmt)
+        except ValueError:
+            pass
+    return _utc_naive(datetime.fromisoformat(text.replace("Z", "+00:00")))

--- a/tests/tasks/test_queries.py
+++ b/tests/tasks/test_queries.py
@@ -1,3 +1,5 @@
+import datetime
+
 from mock import Mock, patch
 from rq import Connection
 from rq.exceptions import NoSuchJobError
@@ -10,6 +12,7 @@ from redash.tasks.queries.execution import (
     enqueue_query,
     execute_query,
 )
+from redash.utils import utcnow
 from tests import BaseTestCase
 
 
@@ -315,3 +318,61 @@ class QueryExecutorTests(BaseTestCase):
             )
             q = models.Query.get_by_id(q.id)
             self.assertEqual(q.schedule_failures, 0)
+
+
+@patch("redash.tasks.queries.execution.get_current_job", side_effect=fetch_job)
+class TestMatviewExecution(BaseTestCase):
+    """End-to-end wiring of matview render/merge/save_meta through QueryExecutor (ML-5958)."""
+
+    MATVIEW_QUERY = (
+        "-- matview: bucket_col=d bucket=day retention=60d refresh=4h v=1\n"
+        "select d, v from t where d >= greatest(/*matview:day*/'1970-01-01', '2026-01-01')"
+    )
+    COLUMNS = [
+        {"name": "d", "friendly_name": "d", "type": "string"},
+        {"name": "v", "friendly_name": "v", "type": "integer"},
+    ]
+
+    def run_scheduled(self, query, rows):
+        with patch.object(PostgreSQL, "run_query") as qr:
+            qr.return_value = ({"columns": self.COLUMNS, "rows": rows}, None)
+            result_id = execute_query(
+                query.query_text,
+                self.factory.data_source.id,
+                {"query_id": query.id},
+                scheduled_query_id=query.id,
+            )
+        return qr.call_args[0][0], models.QueryResult.query.get(result_id)
+
+    def test_incremental_run_renders_window_and_merges(self, _):
+        q = self.factory.create_query(query_text=self.MATVIEW_QUERY, schedule={"interval": 300})
+        old_day = (utcnow() - datetime.timedelta(days=10)).strftime("%Y-%m-%d")
+        today = utcnow().strftime("%Y-%m-%d")
+
+        # First run: no meta -> full load, rendered from now-retention, stored as-is
+        executed, result = self.run_scheduled(q, [{"d": old_day, "v": 1}, {"d": today, "v": 1}])
+        full_start = (utcnow() - datetime.timedelta(days=60)).strftime("%Y-%m-%d")
+        self.assertIn("/*matview:day*/'%s'" % full_start, executed)
+        self.assertEqual(models.Query.get_by_id(q.id).latest_query_data, result)
+
+        # Second run: meta matches -> incremental window from retrieved_at - refresh
+        incr_start = (result.retrieved_at - datetime.timedelta(hours=4)).strftime("%Y-%m-%d")
+        executed, result = self.run_scheduled(q, [{"d": old_day, "v": 2}, {"d": today, "v": 2}])
+        self.assertIn("/*matview:day*/'%s'" % incr_start, executed)
+        # old bucket kept from prev (fresh duplicate dropped by the guard), recent bucket replaced
+        self.assertEqual(result.data["rows"], [{"d": old_day, "v": 1}, {"d": today, "v": 2}])
+        self.assertEqual(models.Query.get_by_id(q.id).latest_query_data, result)
+
+    def test_annotation_change_forces_full_reload(self, _):
+        q = self.factory.create_query(query_text=self.MATVIEW_QUERY, schedule={"interval": 300})
+        today = utcnow().strftime("%Y-%m-%d")
+        self.run_scheduled(q, [{"d": today, "v": 1}])
+
+        q = models.Query.get_by_id(q.id)
+        q.query_text = self.MATVIEW_QUERY.replace("v=1", "v=2")
+        models.db.session.add(q)
+        models.db.session.commit()
+
+        executed, _result = self.run_scheduled(q, [{"d": today, "v": 1}])
+        full_start = (utcnow() - datetime.timedelta(days=60)).strftime("%Y-%m-%d")
+        self.assertIn("/*matview:day*/'%s'" % full_start, executed)

--- a/tests/test_matview.py
+++ b/tests/test_matview.py
@@ -1,0 +1,297 @@
+from datetime import datetime, timedelta, timezone
+from types import SimpleNamespace
+
+from redash.utils import json_dumps, json_loads, matview
+
+ANNOTATION = "-- matview: bucket_col=utc_basic_time bucket=day retention=60d refresh=4h v=1"
+NOW = datetime(2026, 7, 3, 10, 30)
+
+
+class FakeRedis:
+    def __init__(self):
+        self.store = {}
+        self.ttls = {}
+
+    def get(self, key):
+        return self.store.get(key)
+
+    def setex(self, key, ttl, value):
+        self.store[key] = value
+        self.ttls[key] = ttl
+
+    def delete(self, key):
+        self.store.pop(key, None)
+
+
+def make_query_model(query_hash="abc123", prev_data=None, retrieved_at=None):
+    latest = None
+    if prev_data is not None:
+        latest = SimpleNamespace(data=prev_data, retrieved_at=retrieved_at or NOW)
+    return SimpleNamespace(id=42, query_hash=query_hash, latest_query_data=latest)
+
+
+def make_ctx(**overrides):
+    spec = matview.parse(ANNOTATION + "\nselect 1")
+    fields = dict(
+        spec=spec,
+        query_id=42,
+        matview_hash="h",
+        full=False,
+        matview_start=datetime(2026, 7, 3),
+        retention_start=datetime(2026, 5, 4),
+        prev_rows=[],
+        prev_columns=[],
+    )
+    fields.update(overrides)
+    return matview.MatviewCtx(**fields)
+
+
+def columns(*names):
+    return [{"name": n, "friendly_name": n, "type": "string"} for n in names]
+
+
+# --- parse ---
+
+
+def test_parse_day_annotation():
+    spec = matview.parse(ANNOTATION + "\nselect 1")
+    assert spec.bucket_col == "utc_basic_time"
+    assert spec.bucket == "day"
+    assert spec.retention == timedelta(days=60)
+    assert spec.refresh == timedelta(hours=4)
+    assert spec.raw == ANNOTATION
+
+
+def test_parse_hour_annotation_after_other_comments_and_blanks():
+    text = "\n-- some description\n-- matview: bucket_col=t bucket=hour retention=21d refresh=4h\nselect 1"
+    spec = matview.parse(text)
+    assert spec.bucket == "hour"
+    assert spec.retention == timedelta(days=21)
+
+
+def test_parse_returns_none_without_annotation():
+    assert matview.parse("select 1") is None
+    assert matview.parse("") is None
+
+
+def test_parse_ignores_annotation_after_query_body():
+    assert matview.parse("select 1\n" + ANNOTATION) is None
+
+
+def test_parse_returns_none_for_malformed_annotation():
+    assert matview.parse("-- matview: bucket=day retention=60d refresh=4h\nselect 1") is None  # no bucket_col
+    assert matview.parse("-- matview: bucket_col=t bucket=week retention=60d refresh=4h\nselect 1") is None
+    assert matview.parse("-- matview: bucket_col=t bucket=day retention=60x refresh=4h\nselect 1") is None
+    assert matview.parse("-- matview: gibberish\nselect 1") is None
+
+
+def test_parse_respects_feature_flag(monkeypatch):
+    monkeypatch.setattr(matview.settings, "FEATURE_MATVIEW", False)
+    assert matview.parse(ANNOTATION + "\nselect 1") is None
+
+
+# --- render ---
+
+
+def test_render_replaces_day_and_hour_markers():
+    text = (
+        "where a >= greatest(/*matview:day*/'1970-01-01', x)\n"
+        "  and b >= greatest(/*matview:hour*/ '1970-01-01-00', y)\n"
+        "  and c >= '1970-01-01'"
+    )
+    rendered = matview.render(text, datetime(2026, 7, 1))
+    assert "/*matview:day*/'2026-07-01'" in rendered
+    assert "/*matview:hour*/'2026-07-01-00'" in rendered
+    assert "c >= '1970-01-01'" in rendered  # unmarked literal untouched
+
+
+# --- merge ---
+
+
+def test_merge_keeps_prev_window_and_guards_fresh():
+    ctx = make_ctx(
+        matview_start=datetime(2026, 7, 2),
+        retention_start=datetime(2026, 5, 4),
+        prev_rows=[
+            {"utc_basic_time": "2026-05-03", "v": 1},  # outside retention -> dropped
+            {"utc_basic_time": "2026-05-04", "v": 2},  # kept
+            {"utc_basic_time": "2026-07-02", "v": 3},  # >= matview_start -> replaced by fresh
+        ],
+        prev_columns=columns("utc_basic_time", "v"),
+    )
+    data = {
+        "columns": columns("utc_basic_time", "v"),
+        "rows": [
+            {"utc_basic_time": "2026-07-01", "v": 8},  # < matview_start -> double-count guard drops
+            {"utc_basic_time": "2026-07-02", "v": 9},
+        ],
+    }
+    merged = matview.merge(ctx, data, FakeRedis())
+    assert merged["rows"] == [
+        {"utc_basic_time": "2026-05-04", "v": 2},
+        {"utc_basic_time": "2026-07-02", "v": 9},
+    ]
+    assert not ctx.aborted
+
+
+def test_merge_parses_hour_and_iso_buckets():
+    ctx = make_ctx(
+        matview_start=datetime(2026, 7, 2, 6),
+        retention_start=datetime(2026, 6, 1),
+        prev_rows=[
+            {"utc_basic_time": "2026-07-02-05", "v": 1},  # hour format, kept
+            {"utc_basic_time": "2026-07-02T06:00:00", "v": 2},  # ISO, >= start -> dropped
+        ],
+        prev_columns=columns("utc_basic_time", "v"),
+    )
+    data = {"columns": columns("utc_basic_time", "v"), "rows": [{"utc_basic_time": "2026-07-02 07:00:00", "v": 3}]}
+    merged = matview.merge(ctx, data, FakeRedis())
+    assert [r["v"] for r in merged["rows"]] == [1, 3]
+
+
+def test_merge_parses_datetime_object_buckets():
+    ctx = make_ctx(
+        matview_start=datetime(2026, 7, 2),
+        retention_start=datetime(2026, 5, 4),
+        prev_rows=[
+            {"utc_basic_time": datetime(2026, 6, 1), "v": 1},  # naive datetime, kept
+            {"utc_basic_time": datetime(2026, 7, 2, tzinfo=timezone.utc), "v": 2},  # tz-aware, >= start -> dropped
+        ],
+        prev_columns=columns("utc_basic_time", "v"),
+    )
+    data = {"columns": columns("utc_basic_time", "v"), "rows": [{"utc_basic_time": datetime(2026, 7, 2, 8), "v": 3}]}
+    merged = matview.merge(ctx, data, FakeRedis())
+    assert [r["v"] for r in merged["rows"]] == [1, 3]
+
+
+def test_merge_full_passthrough():
+    ctx = make_ctx(full=True)
+    data = {"columns": columns("utc_basic_time"), "rows": [{"utc_basic_time": "2026-07-01"}]}
+    assert matview.merge(ctx, data, FakeRedis()) is data
+    assert not ctx.aborted
+
+
+def test_merge_aborts_on_schema_change():
+    redis = FakeRedis()
+    redis.setex(matview.META_KEY.format(42), 60, "x")
+    ctx = make_ctx(prev_columns=columns("utc_basic_time", "old"))
+    fresh_rows = [{"utc_basic_time": "2026-07-02", "new": 1}]
+    merged = matview.merge(ctx, {"columns": columns("utc_basic_time", "new"), "rows": fresh_rows}, redis)
+    assert merged["rows"] == fresh_rows  # fresh only
+    assert ctx.aborted
+    assert redis.get(matview.META_KEY.format(42)) is None
+
+
+def test_merge_aborts_on_bad_bucket_value():
+    redis = FakeRedis()
+    ctx = make_ctx(prev_columns=columns("utc_basic_time"), prev_rows=[{"utc_basic_time": None}])
+    merged = matview.merge(ctx, {"columns": columns("utc_basic_time"), "rows": []}, redis)
+    assert ctx.aborted
+    assert merged["rows"] == []
+
+
+def test_merge_accepts_json_string_data():
+    ctx = make_ctx(full=True)
+    merged = matview.merge(ctx, json_dumps({"columns": [], "rows": []}), FakeRedis())
+    assert merged == {"columns": [], "rows": []}
+
+
+def test_merge_incremental_accepts_json_string_data():
+    ctx = make_ctx(
+        matview_start=datetime(2026, 7, 2),
+        retention_start=datetime(2026, 5, 4),
+        prev_rows=[{"utc_basic_time": "2026-05-04", "v": 1}],
+        prev_columns=columns("utc_basic_time", "v"),
+    )
+    data = json_dumps({"columns": columns("utc_basic_time", "v"), "rows": [{"utc_basic_time": "2026-07-02", "v": 9}]})
+    merged = matview.merge(ctx, data, FakeRedis())
+    assert merged["rows"] == [{"utc_basic_time": "2026-05-04", "v": 1}, {"utc_basic_time": "2026-07-02", "v": 9}]
+    assert not ctx.aborted
+
+
+# --- plan_window ---
+
+
+def plan(query_model, redis, text=ANNOTATION + "\nselect 1"):
+    return matview.plan_window(matview.parse(text), query_model, redis, now=NOW)
+
+
+def test_plan_window_full_when_no_meta():
+    ctx = plan(make_query_model(prev_data={"columns": [], "rows": []}), FakeRedis())
+    assert ctx.full
+    assert ctx.matview_start == datetime(2026, 5, 4)  # bucket_floor(now - 60d)
+    assert ctx.prev_rows == []
+
+
+def test_plan_window_full_when_hash_mismatch():
+    query_model = make_query_model(prev_data={"columns": [], "rows": []})
+    redis = FakeRedis()
+    redis.setex(matview.META_KEY.format(42), 60, json_dumps({"matview_hash": "stale"}))
+    assert plan(query_model, redis).full
+
+
+def test_plan_window_full_when_no_prev_result():
+    query_model = make_query_model(prev_data=None)
+    redis = FakeRedis()
+    ctx = plan(query_model, redis)
+    redis.setex(matview.META_KEY.format(42), 60, json_dumps({"matview_hash": ctx.matview_hash}))
+    assert plan(query_model, redis).full
+
+
+def test_plan_window_incremental():
+    prev_rows = [{"utc_basic_time": "2026-07-01", "v": 1}]
+    query_model = make_query_model(
+        prev_data={"columns": columns("utc_basic_time", "v"), "rows": prev_rows},
+        retrieved_at=datetime(2026, 7, 3, 9, 0, tzinfo=timezone.utc),
+    )
+    redis = FakeRedis()
+    matview.save_meta(redis, 42, plan(query_model, redis).matview_hash)
+
+    ctx = plan(query_model, redis)
+    assert not ctx.full
+    # bucket_floor(retrieved_at(09:00) - 4h) = floor(05:00) = day start
+    assert ctx.matview_start == datetime(2026, 7, 3)
+    assert ctx.retention_start == datetime(2026, 5, 4)
+    assert ctx.prev_rows == prev_rows
+
+
+def test_plan_window_uses_now_when_clock_skewed():
+    query_model = make_query_model(
+        prev_data={"columns": [], "rows": []},
+        retrieved_at=(NOW + timedelta(hours=2)).replace(tzinfo=timezone.utc),
+    )
+    redis = FakeRedis()
+    matview.save_meta(redis, 42, plan(query_model, redis).matview_hash)
+    ctx = plan(query_model, redis)
+    assert ctx.matview_start == matview._bucket_floor(NOW - timedelta(hours=4), "day")
+
+
+def test_plan_window_hour_bucket_floors_to_hour():
+    text = "-- matview: bucket_col=t bucket=hour retention=21d refresh=4h\nselect 1"
+    query_model = make_query_model(
+        prev_data={"columns": [], "rows": []},
+        retrieved_at=datetime(2026, 7, 3, 9, 45, tzinfo=timezone.utc),
+    )
+    redis = FakeRedis()
+    matview.save_meta(redis, 42, plan(query_model, redis, text=text).matview_hash)
+    ctx = plan(query_model, redis, text=text)
+    assert ctx.matview_start == datetime(2026, 7, 3, 5, 0)
+
+
+def test_matview_hash_changes_with_annotation_and_query():
+    base = plan(make_query_model(), FakeRedis()).matview_hash
+    bumped = plan(
+        make_query_model(),
+        FakeRedis(),
+        text=ANNOTATION.replace("v=1", "v=2") + "\nselect 1",
+    ).matview_hash
+    other_query = plan(make_query_model(query_hash="zzz"), FakeRedis()).matview_hash
+    assert len({base, bumped, other_query}) == 3
+
+
+def test_save_meta_roundtrip():
+    redis = FakeRedis()
+    matview.save_meta(redis, 42, "deadbeef")
+    key = matview.META_KEY.format(42)
+    assert json_loads(redis.get(key)) == {"matview_hash": "deadbeef"}
+    assert redis.ttls[key] == matview.META_TTL


### PR DESCRIPTION
## What type of PR is this?

- [x] Feature

## Description

스케줄 쿼리에 `-- matview:` 어노테이션을 달면 매 실행 전체 기간 재스캔 대신 최근 버킷만 재계산해 이전 결과와 병합한다. 설계·규약·수명 관리는 이 PR 에 포함된 플랜 문서(`.plans/ticketed/ML-5958-matview.md`) 참고. 구현 리뷰는 #19 에서 진행 후 이 브랜치로 squash 머지됨 — 이 PR 하나로 플랜+매뉴얼+구현 전체를 머지한다.

- `redash/utils/matview.py` (신규): `parse` / `plan_window` / `render` / `merge` / `save_meta`
- `QueryExecutor`: 세션 close 전 plan_window(이전 blob 로드), 마커 치환은 runner 에 넘기는 로컬 변수에만 적용, 저장·해쉬는 치환 전 템플릿 그대로 → `update_latest_result`·enqueue 락·알림 무변경
- matview 쿼리는 auto limit 강제 off (스케줄 refresh·수동 실행 2곳) — LIMIT 잘림이 병합 blob 을 오염시키는 것 차단
- `REDASH_FEATURE_MATVIEW` flag (default true), off 면 어노테이션 무시하고 기존과 동일
- 병합 불가 상황(컬럼 스키마 변경, 버킷 파싱 실패)은 fresh 만 저장 + redis 메타 삭제 → 다음 주기 자동 full 재적재. 실행 실패 시 저장 안 함 → 이전 결과 유지, `retrieved_at` 기준 윈도우라 다음 성공이 공백 자동 복구

## How is this tested?

- [x] Unit tests (pytest, jest)
- [x] Manually

**Unit** — `tests/test_matview.py` 23개(parse/render/merge/plan_window/save_meta) + `tests/tasks/test_queries.py::TestMatviewExecution` 2개(QueryExecutor 경유 full→증분 병합, 어노테이션 변경→full 재적재). 영향 범위 스위트(test_queries, test_refresh_queries, test_query_results, test_matview) 76개 전부 통과.

**Manual — 로컬 compose 스택에서 실 Athena 로 검증 (2026-07-03~04)**

구성: 이 브랜치 이미지 + 운영과 동일한 Athena DS. 운영 쿼리 3742 의 5d 변형(`retention=5d refresh=4h`, 마커 3곳, `apply_auto_limit=true` 유지)을 schedule 1h 로 등록. 스택 정의는 플랜 §Verification 2.

| 실행 | Athena 스캔 | 결과 |
|---|---|---|
| 1회차 (full) | 10.38 GB | 679행, `mode=full matview_start=2026-06-28`, redis 메타 생성(TTL 30d) |
| 2회차~ (증분, 밤새 매시간) | 1.9~2.3 GB (**−80%**) | `mode=incremental`, `merged kept=575 fresh=104~107`, kept 행은 이전 실행과 바이트 동일 |

다음날 아침 어노테이션·마커 없는 plain 5d 쿼리를 45초 간격으로 실행해 전 행 비교:

- 682행 키(디멘전 11개 조합) 완전 일치, 양쪽 초과/누락 0
- 6일 버킷 중 5일(당일 포함): 18개 메트릭 전 컬럼 일치 (float 최대 상대차 2.1e-15 = 부동소수점 합산 순서 노이즈)
- 유일한 차이: 최고(最古) 버킷 06-28 의 `bid_response_count` 22행 — d2 필터가 `yyyy-MM-dd-HH` 포맷으로 최고 일자를 하루 중간에서 자르는 **원본 쿼리 고유의 경계 아티팩트** (matview 는 full 로드 시점 기준 14h+ 고정, plain 은 실행 시점 기준 21h+; matview ⊇ plain 방향 확인). merge 결함 아님, 운영 60d 에서 최고 버킷은 하루 뒤 retention 트림으로 빠짐
- auto limit 가드: `apply_auto_limit=true` 상태에서 latest 정상 연결(LIMIT 이 붙었다면 해쉬 불일치로 연결 불가) 확인

retention 트림 (강제 검증): latest blob 에 retention 밖 가짜 버킷(06-27)을 주입 후 증분 실행 — `prev_rows=683 → kept=575`, 새 blob 에서 06-27 탈락 (#19 코멘트).

운영 적용 준비물: 3742 교체용 60d full SQL 은 [#19 코멘트](https://github.com/teamdable/dedash/pull/19#issuecomment-4879568228), 적용본 fork 는 https://redash.internal.dable.io/queries/24991 (draft, 스케줄 없음).

## Related Tickets & Documents

- https://teamdable.atlassian.net/browse/ML-5958
- 구현 리뷰·검증 기록: #19
