### PR TITLE
Skip archived queries in scheduler

### DIFF
--- a/redash/models/__init__.py
+++ b/redash/models/__init__.py
@@ -593,6 +593,7 @@ class Query(ChangeTrackingMixin, TimestampMixin, BelongsToOrgMixin, db.Model):
         queries = (
             Query.query.options(joinedload(Query.latest_query_data).load_only("retrieved_at"))
             .filter(func.jsonb_typeof(Query.schedule) != "null")
+            .filter(Query.is_archived.is_(False))
             .order_by(Query.id)
             .all()
         )

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -163,6 +163,15 @@ class QueryOutdatedQueriesTest(BaseTestCase):
         self.assertNotIn(query, queries)
         self.assertNotIn(query_with_none, queries)
 
+    def test_outdated_queries_skips_archived_queries(self):
+        query = self.create_scheduled_query(interval="3600")
+        self.fake_previous_execution(query, hours=2)
+        query.is_archived = True
+        db.session.add(query)
+        db.session.flush()
+
+        self.assertNotIn(query, models.Query.outdated_queries())
+
     def test_outdated_queries_works_with_ttl_based_schedule(self):
         query = self.create_scheduled_query(interval="3600")
         self.fake_previous_execution(query, hours=2)


### PR DESCRIPTION
## 문제
archived 된 쿼리가 스케줄러에 의해 계속 실행됨.

## 원인
`outdated_queries()`(스케줄 실행 대상 선정)가 archived 제외를 오직 `archive()`의 `schedule = None` 처리에만 의존. schedule 이 남은 채 archived 된 쿼리는 `refresh_queries()` 가 그대로 enqueue 함.

## 수정
`outdated_queries()` 에서 `is_archived` 를 명시적으로 제외 (실행 경로 한 곳).

## 테스트
`test_outdated_queries_skips_archived_queries` 추가. `test_models` · `test_refresh_queries` 23개 통과.