### PR TITLE
Fix Hive query runner crash on DDL with no result set

### DIFF
--- a/redash/query_runner/hive_ds.py
+++ b/redash/query_runner/hive_ds.py
@@ -122,20 +122,23 @@ class Hive(BaseSQLQueryRunner):
 
             column_names = []
             columns = []
+            rows = []
 
-            for column in cursor.description:
-                column_name = column[COLUMN_NAME]
-                column_names.append(column_name)
+            # DDL/DML(CREATE TABLE 등)은 결과셋이 없어 description이 None
+            if cursor.description is not None:
+                for column in cursor.description:
+                    column_name = column[COLUMN_NAME]
+                    column_names.append(column_name)
 
-                columns.append(
-                    {
-                        "name": column_name,
-                        "friendly_name": column_name,
-                        "type": types_map.get(column[COLUMN_TYPE], None),
-                    }
-                )
+                    columns.append(
+                        {
+                            "name": column_name,
+                            "friendly_name": column_name,
+                            "type": types_map.get(column[COLUMN_TYPE], None),
+                        }
+                    )
 
-            rows = [dict(zip(column_names, row)) for row in cursor]
+                rows = [dict(zip(column_names, row)) for row in cursor]
 
             data = {"columns": columns, "rows": rows}
             error = None


### PR DESCRIPTION
## What type of PR is this?

- [x] Bug Fix

## Description

`CREATE TABLE` 등 결과셋을 반환하지 않는 DDL/DML을 Hive 데이터소스(dp-sparksql 포함, Spark Thrift Server)에서 실행하면 `cursor.description`이 `None`이라 이를 순회하다 `'NoneType' object is not iterable`로 실패했다. 실제로 테이블은 생성됐는데도 Redash는 에러로 표시했다.

다른 러너(`pg`/`db2`/`databricks`/`mssql`/`oracle`/`nz`)가 이미 쓰는 `if cursor.description is not None:` 가드를 `Hive.run_query`에 추가해, 결과 없는 문은 빈 결과로 정상 반환한다. `HiveHttp`도 상속으로 함께 수정된다.

실행 실패(문법 오류·권한 등)는 기존과 동일하게 `cursor.execute`에서 예외가 나 에러 메시지로 표시된다.

Compatible versions: PyHive (Hive / Hive HTTP).

## How is this tested?

- [x] Manually

`py_compile` 문법 확인. 로직은 위 6개 러너의 검증된 None 가드 패턴과 동일. DDL 실행 시 에러 없이 빈 결과, DDL 실패 시 에러 메시지 표시로 성공/실패 구분됨.

## Related Tickets & Documents

N/A
