### PR TITLE
Fix Hive runner crash on Spark Thrift Server DDL fetch (null columns)

### DIFF
--- a/redash/query_runner/hive_ds.py
+++ b/redash/query_runner/hive_ds.py
@@ -124,7 +124,7 @@ class Hive(BaseSQLQueryRunner):
             columns = []
             rows = []
 
-            # DDL/DML(CREATE TABLE 등)은 결과셋이 없어 description이 None
+            # DDL/DML(CREATE TABLE 등)은 결과셋이 없음 — Hive는 description이 None
             if cursor.description is not None:
                 for column in cursor.description:
                     column_name = column[COLUMN_NAME]
@@ -138,7 +138,12 @@ class Hive(BaseSQLQueryRunner):
                         }
                     )
 
-                rows = [dict(zip(column_names, row)) for row in cursor]
+                try:
+                    rows = [dict(zip(column_names, row)) for row in cursor]
+                except TypeError:
+                    # Spark Thrift Server는 DDL에도 description을 주지만 fetch 시 columns가 None이라
+                    # pyhive _fetch_more 에서 TypeError 발생 — 실제 결과셋 없음으로 처리
+                    column_names, columns, rows = [], [], []
 
             data = {"columns": columns, "rows": rows}
             error = None


### PR DESCRIPTION
Follow-up to #23. That guard (`cursor.description is None`) doesn't cover the Spark Thrift Server: it returns a **non-None** description for DDL, so the crash just moved to the row fetch — pyhive `_fetch_more` runs `zip(response.results.columns, schema)` with `results.columns=None` → `TypeError: 'NoneType' object is not iterable`.

Verified live: `CREATE EXTERNAL TABLE` via redash→dp-sparksql (ds 374) executes on Spark (table created in Glue) but redash reports the NoneType error; only `DESCRIBE` (real rows) was clean.

Fix wraps the row fetch in `try/except TypeError` → empty result set. Self-checked: DDL-crash→empty, SELECT unaffected, Hive None-description still handled.