### PR TITLE
0바이트 스캔 Athena 쿼리 이력 수집 및 플래닝 지연 경고 (v25.8.0)

### DIFF
--- a/redash/query_runner/athena.py
+++ b/redash/query_runner/athena.py
@@ -32,6 +32,9 @@ except ImportError:
 
 TARGET_REPO_NAME = "dedash"
 
+# Planning time above this means partition pruning failed (a pruned query plans in <1s).
+SLOW_PLANNING_WARN_MS = 5_000
+
 # Global boto3 clients (lazy initialized)
 _athena_client = None
 _s3_client = None
@@ -72,7 +75,7 @@ def _get_execution_history(client, execution_id: str) -> dict | None:
         execution_id: Query execution ID.
 
     Returns:
-        Execution history record dict if data_scanned_bytes > 0, else None.
+        Execution history record dict, or None if the execution cannot be read.
     """
     if not execution_id:
         return None
@@ -81,16 +84,22 @@ def _get_execution_history(client, execution_id: str) -> dict | None:
         response = client.get_query_execution(QueryExecutionId=execution_id)
         execution = response.get("QueryExecution", {})
         stats = execution.get("Statistics", {})
-        data_scanned = stats.get("DataScannedInBytes", 0)
 
-        if data_scanned <= 0:
-            return None
+        planning_time_ms = stats.get("QueryPlanningTimeInMillis", 0)
+        if planning_time_ms > SLOW_PLANNING_WARN_MS:
+            logger.warning(
+                "Athena query planning is slow (%sms) - check that partition filters "
+                "are bounded on both sides: execution_id=%s",
+                planning_time_ms,
+                execution_id,
+            )
 
         record = {
             "execution_id": execution.get("QueryExecutionId"),
             "sql": execution.get("Query"),
             "execution_parameters": "[]",
-            "data_scanned_bytes": data_scanned,
+            "data_scanned_bytes": stats.get("DataScannedInBytes", 0),
+            "query_planning_time_ms": planning_time_ms,
             "submission_time": execution.get("Status", {})
             .get("SubmissionDateTime", datetime.now(timezone.utc))
             .isoformat(),
@@ -111,8 +120,7 @@ def _upload_execution_history_to_s3(athena_client, s3_client, execution_id: str)
     """Upload Athena query execution history to S3 as JSON Lines.
 
     Collects execution metadata for the given execution ID and uploads to S3
-    with 5-minute partitioning based on current UTC time. Only queries with
-    data_scanned_bytes > 0 are included.
+    with 5-minute partitioning based on current UTC time.
 
     Args:
         athena_client: Boto3 Athena client instance.
@@ -133,7 +141,7 @@ def _upload_execution_history_to_s3(athena_client, s3_client, execution_id: str)
 
     if not record:
         logger.debug(
-            "No execution history to upload (data_scanned_bytes <= 0)",
+            "No execution history to upload (execution could not be read)",
             extra={"execution_id": execution_id},
         )
         return None

--- a/tests/query_runner/test_athena.py
+++ b/tests/query_runner/test_athena.py
@@ -8,7 +8,11 @@ import botocore
 import mock
 from botocore.stub import Stubber
 
-from redash.query_runner.athena import Athena
+from redash.query_runner.athena import (
+    SLOW_PLANNING_WARN_MS,
+    Athena,
+    _get_execution_history,
+)
 
 
 class TestGlueSchema(TestCase):
@@ -324,3 +328,41 @@ class TestGlueSchema(TestCase):
                 {"columns": [{"name": "row_id", "type": "int"}], "name": "test1.jdbc_table"},
                 {"columns": [{"name": "row_id", "type": "int"}], "name": "test2.jdbc_table"},
             ]
+
+
+class TestExecutionHistory(TestCase):
+    @staticmethod
+    def _client(data_scanned, planning_ms):
+        client = mock.Mock()
+        client.get_query_execution.return_value = {
+            "QueryExecution": {
+                "QueryExecutionId": "exec-1",
+                "Query": "SELECT max(dt) FROM meta.campaign",
+                "Status": {"State": "SUCCEEDED"},
+                "Statistics": {
+                    "DataScannedInBytes": data_scanned,
+                    "QueryPlanningTimeInMillis": planning_ms,
+                },
+            }
+        }
+        return client
+
+    def test_zero_scan_query_is_recorded(self):
+        """Partition-listing blowups scan 0 bytes, so they must not be dropped."""
+        record = _get_execution_history(self._client(0, 120), "exec-1")
+
+        assert record is not None
+        assert record["data_scanned_bytes"] == 0
+        assert record["query_planning_time_ms"] == 120
+
+    def test_slow_planning_emits_warning(self):
+        with mock.patch("redash.query_runner.athena.logger") as mocked_logger:
+            _get_execution_history(self._client(0, SLOW_PLANNING_WARN_MS + 1), "exec-1")
+
+        assert mocked_logger.warning.called
+
+    def test_fast_planning_emits_no_warning(self):
+        with mock.patch("redash.query_runner.athena.logger") as mocked_logger:
+            _get_execution_history(self._client(1024, SLOW_PLANNING_WARN_MS), "exec-1")
+
+        assert not mocked_logger.warning.called


### PR DESCRIPTION
## What type of PR is this?

- [x] Bug Fix

## Description

PR #28 (`feature/port-dedash-v26.3.0`) 의 동일 수정을 현재 운영 중인 `dable/v25.8.0` 에 반영합니다. 커밋 964b502 cherry-pick 이며 충돌 없이 적용됐습니다.

Athena 쿼리 이력 수집이 `DataScannedInBytes <= 0` 인 실행을 버려 왔습니다 (`redash/query_runner/athena.py`, `_get_execution_history`).

파티션 열거 폭주(파티션 범위가 한쪽만 열려 반대쪽 전 구간을 열거하는 상태)의 전형이 **스캔 0바이트 메타데이터 쿼리**(`max(dt)`)입니다. 그래서 이 필터는 잡아야 할 쿼리를 정확히 골라 버리고 있었습니다. ai-craft 에서 확인된 실제 결함 2건이 `fact_minutely.athena_query_history` 에 한 건도 안 남은 원인입니다.

- **필터 제거** — `data_scanned <= 0` 조기 반환을 없애고 `data_scanned_bytes` 는 그대로 기록합니다
- **`query_planning_time_ms` 수집** — Athena `QueryExecutionStatistics` 의 `QueryPlanningTimeInMillis` 를 레코드에 싣습니다. 스캔 바이트는 폭주를 못 보지만 플래닝 시간은 바로 보입니다

  | | planning time |
  |---|---|
  | 폭주 상태 | 15,920ms |
  | 경계 추가 후 | 462ms |
  | 정상 프루닝 | < 1,000ms |

- **5초 초과 시 경고** — `SLOW_PLANNING_WARN_MS = 5_000` 은 위 두 구간 사이를 넉넉히 갈라 오탐이 사실상 없습니다. 경고까지만 하고 예외를 던지지 않습니다
- 필터 제거로 사실과 어긋나게 된 `_upload_execution_history_to_s3` 의 docstring 과 debug 로그 문구를 함께 고쳤습니다

## How is this tested?

- [x] Unit tests (pytest, jest)

`tests/query_runner/test_athena.py` 의 `TestExecutionHistory` 가 스캔 0바이트 기록, 임계 초과 경고, 임계 이하 무경고를 고정합니다.

로컬 venv 에 테스트 의존성(`redis`, `mock`)이 없어 **테스트 스위트는 실행하지 못했고** `python -m py_compile` 문법 검사만 했습니다. 실제 실행 결과는 CI 로 확인해야 합니다.

## Related Tickets & Documents

- dedash: https://github.com/teamdable/dedash/pull/28 — 동일 수정의 v26.3.0 반영본
- ai-craft: https://github.com/teamdable/ai-craft/pull/5893 — 같은 계측 수정 + 실제 결함 2건 수정 + SQL 리뷰 체크리스트 개정
- data-schema: `query_planning_time_ms` 컬럼 추가
- py-rangers: 이력 ETL 이 새 컬럼을 싣도록 수정
